### PR TITLE
Fix GatewayClass scope

### DIFF
--- a/api/v1alpha1/gatewayclass_types.go
+++ b/api/v1alpha1/gatewayclass_types.go
@@ -21,6 +21,7 @@ import (
 )
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:scope=Cluster
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:openapi-gen=true

--- a/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
@@ -14,7 +14,7 @@ spec:
     listKind: GatewayClassList
     plural: gatewayclasses
     singular: gatewayclass
-  scope: Namespaced
+  scope: Cluster
   validation:
     openAPIV3Schema:
       description: "GatewayClass describes a class of gateways av for defining access

--- a/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: gatewayclasses.networking.x.k8s.io
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: GatewayClassList
     plural: gatewayclasses
     singular: gatewayclass
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: "GatewayClass describes a class of gateways av for defining access

--- a/config/crd/bases/networking.x.k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gateways.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: gateways.networking.x.k8s.io
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: GatewayList
     plural: gateways
     singular: gateway
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: Gateway represents an instantiation of a service-traffic handling

--- a/config/crd/bases/networking.x.k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x.k8s.io_httproutes.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: httproutes.networking.x.k8s.io
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: HTTPRouteList
     plural: httproutes
     singular: httproute
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: HTTPRoute is the Schema for the httproutes API
@@ -33,18 +35,39 @@ spec:
           description: HTTPRouteSpec defines the desired state of HTTPRoute
           properties:
             default:
-              description: Default is the default host to use.
+              description: Default is the default host to use. Default.Hostnames must
+                be an empty list.
               properties:
+                extension:
+                  description: "Extension is an optional, implementation-specific
+                    extension to the \"host\" block. \n Support: custom"
+                  properties:
+                    apiGroup:
+                      description: APIGroup is the group for the resource being referenced.
+                        If APIGroup is not specified, the specified Kind must be in
+                        the core API group. For any other third-party types, APIGroup
+                        is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
+                  - kind
+                  - name
+                  type: object
                 hostnames:
-                  description: 'Hostnames are a list of hosts names to use. TODO:
-                    RFC link'
+                  description: "Hostnames are a list of hosts names that match this
+                    host block. \n TODO: RFC link"
                   items:
                     type: string
                   type: array
-                paths:
-                  description: Paths are a list of HTTP matchers, filters and actions.
+                rules:
+                  description: Rules are a list of HTTP matchers, filters and actions.
                   items:
-                    description: HTTPRoutePath is the configuration for a given path.
+                    description: HTTPRouteRule is the configuration for a given path.
                     properties:
                       action:
                         description: Action defines what happens to the request.
@@ -195,23 +218,43 @@ spec:
                   type: array
               required:
               - hostnames
-              - paths
+              - rules
               type: object
             hosts:
               description: Hosts is a list of Host definitions.
               items:
                 description: HTTPRouteHost is the configuration for a given host.
                 properties:
+                  extension:
+                    description: "Extension is an optional, implementation-specific
+                      extension to the \"host\" block. \n Support: custom"
+                    properties:
+                      apiGroup:
+                        description: APIGroup is the group for the resource being
+                          referenced. If APIGroup is not specified, the specified
+                          Kind must be in the core API group. For any other third-party
+                          types, APIGroup is required.
+                        type: string
+                      kind:
+                        description: Kind is the type of resource being referenced
+                        type: string
+                      name:
+                        description: Name is the name of resource being referenced
+                        type: string
+                    required:
+                    - kind
+                    - name
+                    type: object
                   hostnames:
-                    description: 'Hostnames are a list of hosts names to use. TODO:
-                      RFC link'
+                    description: "Hostnames are a list of hosts names that match this
+                      host block. \n TODO: RFC link"
                     items:
                       type: string
                     type: array
-                  paths:
-                    description: Paths are a list of HTTP matchers, filters and actions.
+                  rules:
+                    description: Rules are a list of HTTP matchers, filters and actions.
                     items:
-                      description: HTTPRoutePath is the configuration for a given
+                      description: HTTPRouteRule is the configuration for a given
                         path.
                       properties:
                         action:
@@ -374,7 +417,7 @@ spec:
                     type: array
                 required:
                 - hostnames
-                - paths
+                - rules
                 type: object
               type: array
           type: object

--- a/config/crd/bases/networking.x.k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x.k8s.io_tcproutes.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: tcproutes.networking.x.k8s.io
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: TcpRouteList
     plural: tcproutes
     singular: tcproute
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: TcpRoute is the Schema for the tcproutes API

--- a/config/crd/bases/networking.x.k8s.io_trafficsplits.yaml
+++ b/config/crd/bases/networking.x.k8s.io_trafficsplits.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
   name: trafficsplits.networking.x.k8s.io
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: TrafficSplitList
     plural: trafficsplits
     singular: trafficsplit
-  scope: ""
+  scope: Namespaced
   validation:
     openAPIV3Schema:
       description: TrafficSplit is the Schema for the trafficsplits API


### PR DESCRIPTION
Gateway class is supposed to be cluster scoped but the CRD was not. In fixing this I found the CRDs were not updated. The first commit I just ran `make manifests`, the second commit I fixed the scoping and rerun that.

Related: https://github.com/kubernetes-sigs/service-apis/issues/14