### PR TITLE
Removes whitespace introduced by commits b2c4093 and ff14200

### DIFF
--- a/docs/devguide/index.html
+++ b/docs/devguide/index.html
@@ -311,7 +311,7 @@
   <a href="#submitting-a-review" class="md-nav__link">
     Submitting a review
   </a>
-  
+
     <nav class="md-nav">
       <ul class="md-nav__list">
         
@@ -319,12 +319,12 @@
   <a href="#verify" class="md-nav__link">
     Verify
   </a>
-  
+
 </li>
-        
+
       </ul>
     </nav>
-  
+
 </li>
       
         <li class="md-nav__item">
@@ -430,17 +430,17 @@
   
     <nav class="md-nav">
       <ul class="md-nav__list">
-        
+
           <li class="md-nav__item">
   <a href="#verify" class="md-nav__link">
     Verify
   </a>
-  
+
 </li>
-        
+
       </ul>
     </nav>
-  
+
 </li>
       
         <li class="md-nav__item">

--- a/hack/delete-crds.sh
+++ b/hack/delete-crds.sh
@@ -24,7 +24,7 @@ RESOURCES="
   gatewayclasses.networking.x.k8s.io
   gateways.networking.x.k8s.io
   httproutes.networking.x.k8s.io
-  tcproutes.networking.x.k8s.io        
+  tcproutes.networking.x.k8s.io
   trafficsplits.networking.x.k8s.io"
 
 for TYPE in ${RESOURCES}; do


### PR DESCRIPTION
Commits `b2c4093` and `ff14200` added unnecessary whitespace to the dev guide. It appears that `make docs` does not clean-up whitespace. Ran `make docs` which added the "release-cadence" section to the dev guide.