### PR TITLE
Add verify-docs command

### DIFF
--- a/docs-src/.mkdocs-exclude
+++ b/docs-src/.mkdocs-exclude
@@ -3,3 +3,4 @@
 .placeholder
 search/search_index.json
 sitemap.xml.gz
+sitemap.xml

--- a/docs.mk
+++ b/docs.mk
@@ -63,7 +63,7 @@ images: .mkdocs.dockerfile.timestamp
 #
 # docs-src/.mkdocs-exclude contains a list of `diff -X` files to
 # exclude from the verification diff.
-verify:
+verify: images
 	$(DOCKER) run \
 		--mount type=bind,source=$(DOCROOT),target=/d \
 		--sig-proxy=true \

--- a/hack/verify-docs.sh
+++ b/hack/verify-docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2014 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/verify-docs.sh
+++ b/hack/verify-docs.sh
@@ -22,11 +22,4 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd $SCRIPT_ROOT
 # Run the docs make
-make -f docs.mk
-
-# If there's any uncommitted changes, fail.
-if git status -s docs/ 2>&1 | grep -E -q '^\s+[MADRCU]'; then
-		echo "Uncommitted changes in docs:" ;
-		git status -s docs;
-		exit 1;
-fi
+make -f docs.mk verify

--- a/hack/verify-docs.sh
+++ b/hack/verify-docs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd $SCRIPT_ROOT
+# Run the docs make
+make -f docs.mk
+
+# If there's any uncommitted changes, fail.
+if git status -s docs/ 2>&1 | grep -E -q '^\s+[MADRCU]'; then
+		echo "Uncommitted changes in docs:" ;
+		git status -s docs;
+		exit 1;
+fi


### PR DESCRIPTION
Adds a simple verify-docs command to `hack/`.

Fixes #19 

I suspect it will be pretty slow right now if there's not reuse of the build instances (I don't know enough about Prow here). I don't see any way around that without:
- Having #3 done
- changing `docs.mk` to have separate build-push and run steps, so we can just use the run step.