### PR TITLE
Use int32 instead of int for listener

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -83,7 +83,7 @@ type Listener struct {
 	//
 	// Support:
 	// +optional
-	Port *int `json:"port"`
+	Port *int32 `json:"port"`
 	// Protocol to use.
 	//
 	// Support:

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -508,7 +508,7 @@ func (in *Listener) DeepCopyInto(out *Listener) {
 	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int)
+		*out = new(int32)
 		**out = **in
 	}
 	if in.Protocol != nil {


### PR DESCRIPTION
All other Kubernetes APIs are using specific integer sizes, so it seems
reasonable to follow suit. In particular, Service's port is using int32,
so reuse that.

Needed for https://github.com/kubernetes-sigs/service-apis/issues/11