### PR TITLE
Evolves the Gateway Name field

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -70,10 +70,24 @@ const (
 
 // Listener defines a
 type Listener struct {
-	// Name can be used to tie this Listener to a ListenerStatus entry with the
-	// same name. Each listener must have a unique name within a Gateway. This
-	// must be a valid DNS_LABEL.
-	Name string `json:"string"`
+	// Name is the listener's name and should be specified as an
+	// RFC 1035 DNS_LABEL [1]:
+	//
+	// [1] https://tools.ietf.org/html/rfc1035
+	//
+	// Each listener of a Gateway must have a unique name. Name is used
+	// for the following features:
+	//
+	// * Associating a listener in ListenerStatus.
+	//
+	// * Generating a wildcard certificate for the subdomain of Name when
+	//   the TLS configuration of an HTTPS listener does not include a
+	//   certificate.
+	//
+	// Support: Core
+	//
+	// +required
+	Name string `json:"name"`
 	// Address requested for this listener. This is optional and behavior
 	// can depend on GatewayClass. If a value is set in the spec and
 	// the request address is invalid, the GatewayClass MUST indicate
@@ -93,9 +107,11 @@ type Listener struct {
 	// Support:
 	// +optional
 	Protocol *string `json:"protocol,omitempty"`
-	// TLS configuraton for the Listener.
+	// TLS is the TLS configuration for the Listener. If unspecified,
+	// the listener will not support TLS connections.
 	//
-	// Support:
+	// Support: Core
+	//
 	// +optional
 	TLS *ListenerTLS `json:"tls,omitempty"`
 	// Extension for this Listener.
@@ -149,13 +165,20 @@ const (
 // - aws: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
 // - azure: https://docs.microsoft.com/en-us/azure/app-service/configure-ssl-bindings#enforce-tls-1112
 type ListenerTLS struct {
-	// Certificates is a list of certificates containing resources
-	// that are bound to the listener.
+	// Certificates is a reference to one or more Kubernetes objects each containing
+	// an identity certificate that is bound to the listener. The hostname in a TLS
+	// SNI client hello message is used for certificate matching and route hostname
+	// selection.
 	//
-	// If apiGroup and kind are empty, will default to Kubernetes Secrets resources.
+	// If unspecified, a wildcard certificate is generated for the subdomain of the
+	// listener's name.
+	//
+	// If apiGroup and kind are empty, defaults to a Kubernetes Secret resource.
 	//
 	// Support: Core (Kubernetes Secrets)
 	// Support: Implementation-specific (Other resource types)
+	//
+	// +optional
 	Certificates []core.TypedLocalObjectReference `json:"certificates,omitempty"`
 	// MinimumVersion of TLS allowed. It is recommended to use one of
 	// the TLS_* constants above. Note: this is not strongly

--- a/config/crd/bases/networking.x.k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gateways.yaml
@@ -52,7 +52,7 @@ spec:
                 description: Listener defines a
                 properties:
                   address:
-                    description: "Address bound on the listener. This is optional
+                    description: "Address requested for this listener. This is optional
                       and behavior can depend on GatewayClass. If a value is set in
                       the spec and the request address is invalid, the GatewayClass
                       MUST indicate this in the associated entry in GatewayStatus.Listeners.
@@ -90,6 +90,15 @@ spec:
                     - kind
                     - name
                     type: object
+                  name:
+                    description: "Name is the listener's name and should be specified
+                      as an RFC 1035 DNS_LABEL [1]: \n [1] https://tools.ietf.org/html/rfc1035
+                      \n Each listener of a Gateway must have a unique name. Name
+                      is used for the following features: \n * Associating a listener
+                      in ListenerStatus. \n * Generating a wildcard certificate for
+                      the subdomain of Name when   the TLS configuration of an HTTPS
+                      listener does not include a   certificate. \n Support: Core"
+                    type: string
                   port:
                     description: "Port is a list of ports associated with the Address.
                       \n Support:"
@@ -99,14 +108,20 @@ spec:
                     description: "Protocol to use. \n Support:"
                     type: string
                   tls:
-                    description: "TLS configuraton for the Listener. \n Support:"
+                    description: "TLS is the TLS configuration for the Listener. If
+                      unspecified, the listener will not support TLS connections.
+                      \n Support: Core"
                     properties:
                       certificates:
-                        description: "Certificates is a list of certificates containing
-                          resources that are bound to the listener. \n If apiGroup
-                          and kind are empty, will default to Kubernetes Secrets resources.
-                          \n Support: Core (Kubernetes Secrets) Support: Implementation-specific
-                          (Other resource types)"
+                        description: "Certificates is a reference to one or more Kubernetes
+                          objects each containing an identity certificate that is
+                          bound to the listener. The hostname in a TLS SNI client
+                          hello message is used for certificate matching and route
+                          hostname selection. \n If unspecified, a wildcard certificate
+                          is generated for the subdomain of the listener's name. \n
+                          If apiGroup and kind are empty, defaults to a Kubernetes
+                          Secret resource. \n Support: Core (Kubernetes Secrets) Support:
+                          Implementation-specific (Other resource types)"
                         items:
                           description: TypedLocalObjectReference contains enough information
                             to let you locate the typed referenced object inside the
@@ -151,6 +166,8 @@ spec:
                     required:
                     - options
                     type: object
+                required:
+                - name
                 type: object
               type: array
             routes:
@@ -183,53 +200,106 @@ spec:
           - routes
           type: object
         status:
-          description: GatewayStatus defines the observed state of Gateway
+          description: GatewayStatus defines the observed state of Gateway.
           properties:
+            conditions:
+              description: Conditions describe the current conditions of the Gateway.
+              items:
+                description: GatewayCondition is an error status for a given route.
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime indicates the last time this condition
+                      changed.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human-understandable message describing
+                      the condition.
+                    type: string
+                  reason:
+                    description: Reason indicates why the condition is in this state.
+                    type: string
+                  status:
+                    description: Status describes the current state of this condition.
+                      Can be "True", "False", or "Unknown".
+                    type: string
+                  type:
+                    description: Type indicates the type of condition.
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
             listeners:
-              description: Listeners is the status for each listener block in the
-                Spec. The status for a given block will match the order as declared
-                in the Spec, e.g. the status for Spec.Listeners[3] will be in Status.Listeners[3].
+              description: Listeners provide status for each listener defined in the
+                Spec. The name in ListenerStatus refers to the corresponding Listener
+                of the same name.
               items:
                 description: ListenerStatus is the status associated with each listener
                   block.
                 properties:
                   address:
-                    type: string
-                  errors:
-                    description: Errors is a list of reasons why a given Listener
-                      Spec is not valid. Errors will be empty if the Spec is valid.
+                    description: Address bound on this listener.
+                    properties:
+                      type:
+                        description: "Type of the Address. This is one of the *AddressType
+                          constants. \n Support: Extended"
+                        type: string
+                      value:
+                        description: 'Value. Examples: "1.2.3.4", "128::1", "my-ip-address".
+                          Validity of the values will depend on `Type` and support
+                          by the controller.'
+                        type: string
+                    required:
+                    - type
+                    - value
+                    type: object
+                  conditions:
+                    description: Conditions describe the current condition of this
+                      listener.
                     items:
-                      description: ListenerError is an error status for a given ListenerSpec.
+                      description: ListenerCondition is an error status for a given
+                        listener.
                       properties:
+                        lastTransitionTime:
+                          description: LastTransitionTime indicates the last time
+                            this condition changed.
+                          format: date-time
+                          type: string
                         message:
-                          description: Message is a human-understandable error message.
+                          description: Message is a human-understandable message describing
+                            the condition.
                           type: string
                         reason:
-                          description: Reason is a automation friendly reason code
-                            for the error.
+                          description: Reason indicates why the condition is in this
+                            state.
+                          type: string
+                        status:
+                          description: Status describes the current state of this
+                            condition. Can be "True", "False", or "Unknown".
+                          type: string
+                        type:
+                          description: Type indicates the type of condition.
                           type: string
                       required:
-                      - message
-                      - reason
+                      - status
+                      - type
                       type: object
                     type: array
+                  name:
+                    description: Name is the name of the listener this status refers
+                      to.
+                    type: string
                 required:
                 - address
-                - errors
-                type: object
-              type: array
-            routes:
-              description: Routes is the status for each attached route to the Gateway.
-                The status for a given route will match the orer as declared in the
-                Spec, e.g. the status for Spec.Routes[3] will be in Status.Routes[3].
-              items:
-                description: GatewayRouteStatus is the status associated with a given
-                  (Gateway, Route) pair.
+                - conditions
+                - name
                 type: object
               type: array
           required:
+          - conditions
           - listeners
-          - routes
           type: object
       type: object
   version: v1alpha1


### PR DESCRIPTION
Evolves the following `Gateway` fields:
- `Name` used for generating a listener wildcard certificate when unspecified by the TLS configuration.
- `Certificate` godocs.

Partially fixes https://github.com/kubernetes-sigs/service-apis/issues/49

/assign @bowei 