### PR TITLE
Introduce virtual servers as a concrete type.

### DIFF
--- a/api/v1alpha1/httproute_types.go
+++ b/api/v1alpha1/httproute_types.go
@@ -19,38 +19,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// HTTPRouteSpec defines the desired state of HTTPRoute
-type HTTPRouteSpec struct {
-	// Hosts is a list of Host definitions.
-	Hosts []HTTPRouteHost `json:"hosts,omitempty"`
+// HTTPServerSpec defines the desired state of HTTPServer.
+type HTTPServerSpec struct {
+	// Hostnames are the set of domain name that refers to this
+	// HTTPServer. These names must be unique across the Listener.
+	Hostnames []string `json:"hostnames,omitempty"`
 
-	// Default is the default host to use. Default.Hostnames must
-	// be an empty list.
+	// If this host has multiple names, each name should be present in the
+	// server certificate as a DNS SAN.
 	//
-	// +optional
-	Default *HTTPRouteHost `json:"default"`
-}
-
-// HTTPRouteHost is the configuration for a given host.
-type HTTPRouteHost struct {
-	// Hostname is the fully qualified domain name of a network host,
-	// as defined by RFC 3986. Note the following deviations from the
-	// "host" part of the URI as defined in the RFC:
-	//
-	// 1. IPs are not allowed.
-	// 2. The `:` delimiter is not respected because ports are not allowed.
-	//
-	// Incoming requests are matched against Hostname before processing HTTPRoute
-	// rules. For example, if the request header contains host: foo.example.com,
-	// an HTTPRoute with hostname foo.example.com will match. However, an
-	// HTTPRoute with hostname example.com or bar.example.com will not match.
-	// If Hostname is unspecified, the Gateway routes all traffic based on
-	// the specified rules.
-	//
-	// Support: Core
-	//
-	// +optional
-	Hostname string `json:"hostname,omitempty"`
+	// The ALPNProtocols field in this TLSAcceptor must contain only valid
+	// HTTP protocol identifiers, i.e. "http/0.9", "http/1.0", "http/1.1",
+	// "h2". Implementations may accept only a subset of these values if
+	// the underlying proxy implementation does not implement the
+	// corresponding HTTP protocol version.
+	TLS *TLSAcceptor
 
 	// Rules are a list of HTTP matchers, filters and actions.
 	Rules []HTTPRouteRule `json:"rules"`
@@ -243,8 +226,8 @@ type RouteActionExtensionObjectReference = LocalObjectReference
 // +k8s:deepcopy-gen=false
 type RouteHostExtensionObjectReference = LocalObjectReference
 
-// HTTPRouteStatus defines the observed state of HTTPRoute.
-type HTTPRouteStatus struct {
+// HTTPServerStatus defines the observed state of HTTPServer.
+type HTTPServerStatus struct {
 	Gateways []GatewayObjectReference `json:"gateways"`
 }
 
@@ -262,24 +245,24 @@ type GatewayObjectReference struct {
 
 // +kubebuilder:object:root=true
 
-// HTTPRoute is the Schema for the httproutes API
-type HTTPRoute struct {
+// HTTPServer is a virtual HTTP server, hosted by a Gateway.
+type HTTPServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   HTTPRouteSpec   `json:"spec,omitempty"`
-	Status HTTPRouteStatus `json:"status,omitempty"`
+	Spec   HttpHostSpec   `json:"spec,omitempty"`
+	Status HttpHostStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
-// HTTPRouteList contains a list of HTTPRoute
-type HTTPRouteList struct {
+// HTTPServerList contains a list of HTTPServer
+type HTTPServerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []HTTPRoute `json:"items"`
+	Items           []HTTPServer `json:"items"`
 }
 
 func init() {
-	SchemeBuilder.Register(&HTTPRoute{}, &HTTPRouteList{})
+	SchemeBuilder.Register(&HTTPServer{}, &HTTPServerList{})
 }

--- a/api/v1alpha1/tcproute_types.go
+++ b/api/v1alpha1/tcproute_types.go
@@ -19,25 +19,39 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // TcpRouteSpec defines the desired state of TcpRoute
-type TcpRouteSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+type StreamServerSpec struct {
+	// Hostnames are the set of domain name that refers to this
+	// StreamServer. These names must be unique across the Listener.
+	Hostnames []string `json:"hostnames,omitempty"`
+
+	// If this host has multiple names, each name should be present in the
+	// server certificate as a DNS SAN.
+	//
+	// If this server does not have a TLS configuration, or the TLS
+	// configuration does not specify any ALPN protocol names, it must
+	// be attached to a Dedicated listener.
+	TLS *TLSAcceptor
+
+	// Rules are a list of HTTP matchers, filters and actions.
+	Rules []StreamRouteRule `json:"rules"`
 }
 
-// TcpRouteStatus defines the observed state of TcpRoute
-type TcpRouteStatus struct {
+// StreamrouteRule describes how a byte stream is forwarded to its destination.
+type StreamRouteRule struct {
+}
+
+// StreamServerStatus defines the observed state of TcpRoute
+type StreamServerStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 }
 
 // +kubebuilder:object:root=true
 
-// TcpRoute is the Schema for the tcproutes API
-type TcpRoute struct {
+// StreamServer is a virtual server that accepts a stream of bytes and forwards
+// it to a subsequent destination.
+type StreamServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 

--- a/api/v1alpha1/tcproute_types.go
+++ b/api/v1alpha1/tcproute_types.go
@@ -19,7 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TcpRouteSpec defines the desired state of TcpRoute
+// StreamServerSpec defines the desired state of StreamServer
 type StreamServerSpec struct {
 	// Hostnames are the set of domain name that refers to this
 	// StreamServer. These names must be unique across the Listener.
@@ -41,7 +41,7 @@ type StreamServerSpec struct {
 type StreamRouteRule struct {
 }
 
-// StreamServerStatus defines the observed state of TcpRoute
+// StreamServerStatus defines the observed state of StreamServer
 type StreamServerStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
@@ -55,19 +55,19 @@ type StreamServer struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   TcpRouteSpec   `json:"spec,omitempty"`
-	Status TcpRouteStatus `json:"status,omitempty"`
+	Spec   StreamServerSpec   `json:"spec,omitempty"`
+	Status StreamServerStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 
-// TcpRouteList contains a list of TcpRoute
-type TcpRouteList struct {
+// StreamServerList contains a list of StreamServer
+type StreamServerList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []TcpRoute `json:"items"`
+	Items           []StreamServer `json:"items"`
 }
 
 func init() {
-	SchemeBuilder.Register(&TcpRoute{}, &TcpRouteList{})
+	SchemeBuilder.Register(&StreamServer{}, &StreamServerList{})
 }

--- a/api/v1alpha1/tls_types.go
+++ b/api/v1alpha1/tls_types.go
@@ -1,0 +1,95 @@
+/*
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// TLSConfiguration describes the TLS configuration for a party in a TLS
+// session.
+//
+// References
+// - nginx: https://nginx.org/en/docs/http/configuring_https_servers.html
+// - envoy: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/auth/cert.proto
+// - haproxy: https://www.haproxy.com/documentation/aloha/9-5/traffic-management/lb-layer7/tls/
+// - gcp: https://cloud.google.com/load-balancing/docs/use-ssl-policies#creating_an_ssl_policy_with_a_custom_profile
+// - aws: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html#describe-ssl-policies
+// - azure: https://docs.microsoft.com/en-us/azure/app-service/configure-ssl-bindings#enforce-tls-1112
+type TLSConfiguration struct {
+	// ALPNProtocols is the list of IANA-registered ALPN protocol names
+	// that this TLS party is willing to accept.
+	//
+	// https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+	//
+	// +optional
+	ALPNProtocols []string `json:"alpnProtocols,omitempty"`
+	// Certificates is a list of references to Kubernetes objects that each
+	// contain an identity certificate that is bound to the listener.  The
+	// host name in a TLS SNI client hello message is used for certificate
+	// matching and route host name selection.  The SNI server_name must
+	// match a route host name for the Gateway to route the TLS request.  If
+	// an entry in this list specifies the empty string for both the group
+	// and the resource, the resource defaults to "secret".  An
+	// implementation may support other resources (for example, resource
+	// "mycertificate" in group "networking.acme.io").
+	//
+	// Support: Core (Kubernetes Secrets)
+	// Support: Implementation-specific (Other resource types)
+	//
+	// +required
+	Certificates []CertificateObjectReference `json:"certificates,omitempty"`
+	// MinimumVersion of TLS allowed. It is recommended to use one of
+	// the TLS_* constants above. Note: this is not strongly
+	// typed to allow implementation-specific versions to be used without
+	// requiring updates to the API types. String must be of the form
+	// "<protocol><major>_<minor>".
+	//
+	// Support: Core for TLS1_{1,2,3}. Implementation-specific for all other
+	// values.
+	//
+	// +optional
+	MinimumVersion *string `json:"minimumVersion"`
+	// Options are a list of key/value pairs to give extended options
+	// to the provider.
+	//
+	// There variation among providers as to how ciphersuites are
+	// expressed. If there is a common subset for expressing ciphers
+	// then it will make sense to loft that as a core API
+	// construct.
+	//
+	// Support: Implementation-specific.
+	Options map[string]string `json:"options"`
+}
+
+// TLSPeerValidation policy specifies the requirements that a party in a TLS
+// session has on communicating with its peer.
+type TLSPeerValidationPolicy struct {
+	// TODO(jpeach): obviously!
+}
+
+// TLSAcceptor describes the TLS configuration for accepting TLS sessions.
+type TLSAcceptor struct {
+	TLSConfiguration `json:",inline"`
+	Peer             TLSPeerValidationPolicy `json:"peer"`
+}
+
+// TLSInitiator describes the TLS configuration for a party that initiates TLS
+// sessions.
+//
+// TODO(jpeach): consider merging TLSAcceptor and TLSInitiator if it turns out
+// that there are no differences between the information we need to capture for
+// each usage.
+type TLSInitiator struct {
+	TLSConfiguration `json:",inline"`
+	Peer             TLSPeerValidationPolicy `json:"peer"`
+}


### PR DESCRIPTION
This is an RFC sketch for discussion, not intended to be merged. Please do not merge.

Since the HTTPRoute terminates traffic (either HTTP or TLS), it behaves
more like an endpoint than list a route. Introducinng the explicit concept
of a virtual server improves the clarity of the object model by renaming
the existing Route objects using terminology that better describes what
they do.

Now that we have virtual server terminology, attach TLS information at
the server layer. This gives an explicit association between network
applications (as represented by a virtual server) and their TLS
configuration.

Listeners are still resources that are attached to a gateway, but they not
have a type, which can be "combined" or "dedicated". Dedicated listeners
host up to 1 virtual server, where combined listeners may host many
virtual servers. Combined listeners must have a discriminator in the
server protocol stack, which the controller implementation is required
to validate.

The TLS configuration is barely a sketch, but it consists of the
configuration for the comunicating party and a conviguration for
validating its peer. It's not yet clear to me if this structure will
suffice for both initiators and receivers.

Signed-off-by: James Peach <jpeach@vmware.com>

xref #72 
xref #94 
xref #49 