### PR TITLE
Updates and Includes Example Resources in Install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,19 @@ serve:
 clean:
 	make -f docs.mk clean
 
-# Install the CRD's to a pre-existing cluster.
+# Install the CRD's and example resources to a pre-existing cluster.
 .PHONY: install
-install:
+install: crd example
+
+# Install the CRD's to a pre-existing cluster.
+.PHONY: crd
+crd:
 	make -f kubebuilder.mk install
+
+# Install the example resources to a pre-existing cluster.
+.PHONY: example
+example:
+	hack/install-examples.sh
 
 # Remove installed CRD's and CR's.
 .PHONY: uninstall

--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -16,11 +16,12 @@ metadata:
 spec:
   class: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
-  - protocol: HTTP
+  - name: my-http-listener
+    protocol: HTTP
   routes:
   - name: http-app-1
-    namespace: default
-    kind: HTTPRoute
+    group: networking.x.k8s.io
+    resource: HTTPRoute
 ---
 kind: HTTPRoute
 apiVersion: networking.x.k8s.io/v1alpha1
@@ -36,5 +37,6 @@ spec:
             path: /bar
           action:
             forwardTo:
-              kind: Service
+              resource: Service
+              group: core
               name: my-service

--- a/hack/install-examples.sh
+++ b/hack/install-examples.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Install all example service-apis resources.
+kubectl apply -f examples


### PR DESCRIPTION
Previously, the example resources failed to install. This PR updates the example to reflect the latest api changes. Additionally, the example resources are included in `make install`.

/assign @bowei 
/cc @Miciah 