### PR TITLE
Fix route selectors for the basic example

### DIFF
--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -19,15 +19,18 @@ spec:
   - name: my-http-listener
     protocol: HTTP
   routes:
-    namespaceSelector:
+    namespaceSelector: {}
+    routeSelector:
       matchLabels:
-        "": ""
+        "app": "foo"
 ---
 kind: HTTPRoute
 apiVersion: networking.x.k8s.io/v1alpha1
 metadata:
   name: http-app-1
   namespace: default
+  labels:
+    app: foo
 spec:
   hosts:
     - hostnames:


### PR DESCRIPTION
Change namespaceSelector to empty value, since empty string is not a valid key.
Add routeSelector with simple example of matchLabels.
Add same labels value to HTTPRoute in order to match gateway's routeSelector.