### PR TITLE
Add Conditions for Listener name errors.

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -373,6 +373,12 @@ const (
 	ConditionListenerNotReady ListenerConditionType = "ListenerNotReady"
 	// ConditionInvalidAddress indicates the Address is invalid.
 	ConditionInvalidAddress ListenerConditionType = "InvalidAddress"
+	// ConditionInvalidName indicates that the name given to the Listener
+	// did not meet the requirements of the gateway controller.
+	ConditionInvalidName ListenerConditionType = "InvalidName"
+	// ConditionNameConflict indicates that two or more Listeners with
+	// the same name were bound to this gateway.
+	ConditionNameConflict ListenerConditionType = "NameConflict"
 )
 
 // ListenerCondition is an error status for a given listener.


### PR DESCRIPTION
Listeners have names, which can fail validation rules, so add a
`ConditionInvalidName` so that the controller can be more specific that
`ConditionInvalidListener`.

Listener names must be unique within a gateway. so add
`ConditionNameConflict` for use when this constraint is violated.

Signed-off-by: James Peach <jpeach@vmware.com>