### PR TITLE
Change networking.x.k8s.io to networking.x-k8s.io

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,5 +1,5 @@
 version: "2"
-domain: x.k8s.io
+domain: x-k8s.io
 repo: sigs.k8s.io/service-apis
 resources:
 - group: networking

--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -61,7 +61,7 @@ type GatewaySpec struct {
 	// a cluster operator to expose a cluster resource (i.e. Service) by
 	// externally-reachable URL, load-balance traffic and terminate SSL/TLS.
 	// Typically, a route is a "httproute" or "tcproute" in group
-	// "networking.x.k8s.io". However, an implementation may support other resources.
+	// "networking.x-k8s.io". However, an implementation may support other resources.
 	//
 	// Support: Core
 	//

--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -206,7 +206,7 @@ message GatewaySpec {
   // a cluster operator to expose a cluster resource (i.e. Service) by
   // externally-reachable URL, load-balance traffic and terminate SSL/TLS.
   // Typically, a route is a "httproute" or "tcproute" in group
-  // "networking.x.k8s.io". However, an implementation may support other resources.
+  // "networking.x-k8s.io". However, an implementation may support other resources.
   //
   // Support: Core
   optional RouteBindingSelector routes = 3;

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,7 +15,7 @@ limitations under the License.
 
 // Package v1alpha1 contains API Schema definitions for the networking v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=networking.x.k8s.io
+// +groupName=networking.x-k8s.io
 package v1alpha1
 
 import (
@@ -25,7 +25,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "networking.x.k8s.io", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "networking.x-k8s.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gatewayclasses.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
-  name: gatewayclasses.networking.x.k8s.io
+  name: gatewayclasses.networking.x-k8s.io
 spec:
-  group: networking.x.k8s.io
+  group: networking.x-k8s.io
   names:
     kind: GatewayClass
     listKind: GatewayClassList

--- a/config/crd/bases/networking.x.k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x.k8s.io_gateways.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
-  name: gateways.networking.x.k8s.io
+  name: gateways.networking.x-k8s.io
 spec:
-  group: networking.x.k8s.io
+  group: networking.x-k8s.io
   names:
     kind: Gateway
     listKind: GatewayList
@@ -177,7 +177,7 @@ spec:
                 a request and allows a cluster operator to expose a cluster resource
                 (i.e. Service) by externally-reachable URL, load-balance traffic and
                 terminate SSL/TLS. Typically, a route is a \"httproute\" or \"tcproute\"
-                in group \"networking.x.k8s.io\". However, an implementation may support
+                in group \"networking.x-k8s.io\". However, an implementation may support
                 other resources. \n Support: Core"
               properties:
                 namespaceSelector:

--- a/config/crd/bases/networking.x.k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x.k8s.io_httproutes.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
-  name: httproutes.networking.x.k8s.io
+  name: httproutes.networking.x-k8s.io
 spec:
-  group: networking.x.k8s.io
+  group: networking.x-k8s.io
   names:
     kind: HTTPRoute
     listKind: HTTPRouteList

--- a/config/crd/bases/networking.x.k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x.k8s.io_tcproutes.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
-  name: tcproutes.networking.x.k8s.io
+  name: tcproutes.networking.x-k8s.io
 spec:
-  group: networking.x.k8s.io
+  group: networking.x-k8s.io
   names:
     kind: TcpRoute
     listKind: TcpRouteList

--- a/config/crd/bases/networking.x.k8s.io_trafficsplits.yaml
+++ b/config/crd/bases/networking.x.k8s.io_trafficsplits.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.2.4
   creationTimestamp: null
-  name: trafficsplits.networking.x.k8s.io
+  name: trafficsplits.networking.x-k8s.io
 spec:
-  group: networking.x.k8s.io
+  group: networking.x-k8s.io
   names:
     kind: TrafficSplit
     listKind: TrafficSplitList

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -2,11 +2,11 @@
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
 resources:
-- bases/networking.x.k8s.io_gatewayclasses.yaml
-- bases/networking.x.k8s.io_gateways.yaml
-- bases/networking.x.k8s.io_httproutes.yaml
-- bases/networking.x.k8s.io_trafficsplits.yaml
-- bases/networking.x.k8s.io_tcproutes.yaml
+- bases/networking.x-k8s.io_gatewayclasses.yaml
+- bases/networking.x-k8s.io_gateways.yaml
+- bases/networking.x-k8s.io_httproutes.yaml
+- bases/networking.x-k8s.io_trafficsplits.yaml
+- bases/networking.x-k8s.io_tcproutes.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/crd/patches/cainjection_in_gatewayclasses.yaml
+++ b/config/crd/patches/cainjection_in_gatewayclasses.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: gatewayclasses.networking.x.k8s.io
+  name: gatewayclasses.networking.x-k8s.io

--- a/config/crd/patches/cainjection_in_gateways.yaml
+++ b/config/crd/patches/cainjection_in_gateways.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: gateways.networking.x.k8s.io
+  name: gateways.networking.x-k8s.io

--- a/config/crd/patches/cainjection_in_httproutes.yaml
+++ b/config/crd/patches/cainjection_in_httproutes.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: httproutes.networking.x.k8s.io
+  name: httproutes.networking.x-k8s.io

--- a/config/crd/patches/cainjection_in_tcproutes.yaml
+++ b/config/crd/patches/cainjection_in_tcproutes.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: tcproutes.networking.x.k8s.io
+  name: tcproutes.networking.x-k8s.io

--- a/config/crd/patches/cainjection_in_trafficsplits.yaml
+++ b/config/crd/patches/cainjection_in_trafficsplits.yaml
@@ -5,4 +5,4 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     certmanager.k8s.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
-  name: trafficsplits.networking.x.k8s.io
+  name: trafficsplits.networking.x-k8s.io

--- a/config/crd/patches/webhook_in_gatewayclasses.yaml
+++ b/config/crd/patches/webhook_in_gatewayclasses.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: gatewayclasses.networking.x.k8s.io
+  name: gatewayclasses.networking.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_gateways.yaml
+++ b/config/crd/patches/webhook_in_gateways.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: gateways.networking.x.k8s.io
+  name: gateways.networking.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_httproutes.yaml
+++ b/config/crd/patches/webhook_in_httproutes.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: httproutes.networking.x.k8s.io
+  name: httproutes.networking.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_tcproutes.yaml
+++ b/config/crd/patches/webhook_in_tcproutes.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: tcproutes.networking.x.k8s.io
+  name: tcproutes.networking.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/crd/patches/webhook_in_trafficsplits.yaml
+++ b/config/crd/patches/webhook_in_trafficsplits.yaml
@@ -3,7 +3,7 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: trafficsplits.networking.x.k8s.io
+  name: trafficsplits.networking.x-k8s.io
 spec:
   conversion:
     strategy: Webhook

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,7 +7,7 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - gatewayclasses
   verbs:
@@ -19,7 +19,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - gatewayclasses/status
   verbs:
@@ -27,7 +27,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - gateways
   verbs:
@@ -39,7 +39,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - gateways/status
   verbs:
@@ -47,7 +47,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - httproutes
   verbs:
@@ -59,7 +59,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - httproutes/status
   verbs:
@@ -67,7 +67,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - tcproutes
   verbs:
@@ -79,7 +79,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - tcproutes/status
   verbs:
@@ -87,7 +87,7 @@ rules:
   - patch
   - update
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - trafficsplits
   verbs:
@@ -99,7 +99,7 @@ rules:
   - update
   - watch
 - apiGroups:
-  - networking.x.k8s.io
+  - networking.x-k8s.io
   resources:
   - trafficsplits/status
   verbs:

--- a/config/samples/networking_v1alpha1_gateway.yaml
+++ b/config/samples/networking_v1alpha1_gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 kind: Gateway
 metadata:
   name: gateway-sample
@@ -21,8 +21,8 @@ spec:
           name: gateway-sample
         minimumVersion: TLS_1_0
         options:
-          gateway-controller.vendor.x.k8s.io/tls-option-1: value1
-          gateway-controller.vendor.x.k8s.io/tls-option-2: value2
+          gateway-controller.vendor.x-k8s.io/tls-option-1: value1
+          gateway-controller.vendor.x-k8s.io/tls-option-2: value2
       extension:
         apiGroup: sample.vendor.io
         kind: MyProtocolListener

--- a/config/samples/networking_v1alpha1_gatewayclass.yaml
+++ b/config/samples/networking_v1alpha1_gatewayclass.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 kind: GatewayClass
 metadata:
   name: gatewayclass-sample

--- a/config/samples/networking_v1alpha1_httproute.yaml
+++ b/config/samples/networking_v1alpha1_httproute.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 kind: HttpRoute
 metadata:
   name: httproute-sample

--- a/config/samples/networking_v1alpha1_tcproute.yaml
+++ b/config/samples/networking_v1alpha1_tcproute.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 kind: TcpRoute
 metadata:
   name: tcproute-sample

--- a/config/samples/networking_v1alpha1_trafficsplit.yaml
+++ b/config/samples/networking_v1alpha1_trafficsplit.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 kind: TrafficSplit
 metadata:
   name: trafficsplit-sample

--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -30,8 +30,8 @@ type GatewayReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=gateways,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=gateways/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gateways,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gateways/status,verbs=get;update;patch
 
 // Reconcile the changes.
 func (r *GatewayReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/gatewayclass_controller.go
+++ b/controllers/gatewayclass_controller.go
@@ -30,8 +30,8 @@ type GatewayClassReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=gatewayclasses,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=gatewayclasses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=gatewayclasses/status,verbs=get;update;patch
 
 // Reconcile the changes.
 func (r *GatewayClassReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/httproute_controller.go
+++ b/controllers/httproute_controller.go
@@ -30,8 +30,8 @@ type HTTPRouteReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=httproutes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=httproutes/status,verbs=get;update;patch
 
 // Reconcile the changes.
 func (r *HTTPRouteReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/tcproute_controller.go
+++ b/controllers/tcproute_controller.go
@@ -30,8 +30,8 @@ type TcpRouteReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=tcproutes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=tcproutes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=tcproutes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=tcproutes/status,verbs=get;update;patch
 
 // Reconcile the changes.
 func (r *TcpRouteReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/controllers/trafficsplit_controller.go
+++ b/controllers/trafficsplit_controller.go
@@ -30,8 +30,8 @@ type TrafficSplitReconciler struct {
 	Log logr.Logger
 }
 
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=trafficsplits,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=networking.x.k8s.io,resources=trafficsplits/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=trafficsplits,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=networking.x-k8s.io,resources=trafficsplits/status,verbs=get;update;patch
 
 // Reconcile the changes.
 func (r *TrafficSplitReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {

--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -1,5 +1,5 @@
 kind: GatewayClass
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: acme-lb
 controller: acme.io/gateway-controller
@@ -9,7 +9,7 @@ parameters:
   name: acme-lb-config
 ---
 kind: Gateway
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: my-gateway
   namespace: default
@@ -25,7 +25,7 @@ spec:
         "app": "foo"
 ---
 kind: HTTPRoute
-apiVersion: networking.x.k8s.io/v1alpha1
+apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-1
   namespace: default

--- a/hack/delete-crds.sh
+++ b/hack/delete-crds.sh
@@ -21,11 +21,11 @@ set -o pipefail
 # Delete all CR and CRDs installed by service-apis.
 
 RESOURCES="
-  gatewayclasses.networking.x.k8s.io
-  gateways.networking.x.k8s.io
-  httproutes.networking.x.k8s.io
-  tcproutes.networking.x.k8s.io
-  trafficsplits.networking.x.k8s.io"
+  gatewayclasses.networking.x-k8s.io
+  gateways.networking.x-k8s.io
+  httproutes.networking.x-k8s.io
+  tcproutes.networking.x-k8s.io
+  trafficsplits.networking.x-k8s.io"
 
 for TYPE in ${RESOURCES}; do
   kubectl delete ${TYPE} --all


### PR DESCRIPTION
Use of x.k8s.io caused many parts of k8s to think that the CRDs
were part of group `x` under the core APIs. We should use x-k8s
instead.

Fixes #147