### PR TITLE
Adds CRD Verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# The controller-gen command for generating CRDs from API definitions.
+CONTROLLER_GEN=GOFLAGS=-mod=vendor go run sigs.k8s.io/controller-tools/cmd/controller-gen
+# The output directory for generated CRDs.
+CRD_OUTPUT_DIR ?= "config/crd/bases"
+# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
+CRD_OPTIONS ?= "crd:trivialVersions=true"
+
 all: controller docs
 
 # Kubebuilder driven custom resource definitions.
@@ -32,6 +39,11 @@ serve:
 .PHONY: clean
 clean:
 	make -f docs.mk clean
+
+# Generate manifests e.g. CRD, RBAC etc.
+.PHONY: manifests
+manifests:
+	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=$(CRD_OUTPUT_DIR)
 
 # Install the CRD's and example resources to a pre-existing cluster.
 .PHONY: install

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd "${SCRIPT_ROOT}"
+
+DIFFROOT="${SCRIPT_ROOT}/config/crd/bases"
+TMP_DIFFROOT="${SCRIPT_ROOT}/_tmp/config/crd/bases"
+_tmp="${SCRIPT_ROOT}/_tmp"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+cleanup
+
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
+
+CRD_OUTPUT_DIR="${TMP_DIFFROOT}" make manifests
+echo "diffing ${DIFFROOT} against freshly generated codegen in ${TMP_DIFFROOT}"
+ret=0
+diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run 'make manifests'"
+  exit 1
+fi


### PR DESCRIPTION
Previously, commits that altered API definitions may get merged without the corresponding CRD being updated. This PR, combined with https://github.com/kubernetes/test-infra/pull/17196, will ensure CRDs are verified to match API definitions before the corresponding commit is merged.

/assign @bowei 
/cc @robscott 