### PR TITLE
Adds a GitHub Issues template for reporting bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,17 @@
+---
+name: Bug Report
+about: Report a bug encountered with the service-apis project
+labels: kind/bug
+
+---
+<!-- Please use this template while reporting a bug and provide as much info as possible.
+Not doing so may result in your bug not being addressed in a timely manner. Thank you!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:


### PR DESCRIPTION
Previously, all GitHub Issues were considered "Enhancements". This PR adds a template for reporting bugs.

/assign @bowei @robscott 
/cc @Miciah 