### PR TITLE
Mark Gateway status fields optional

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -232,10 +232,12 @@ type ListenerExtensionObjectReference = LocalObjectReference
 // GatewayStatus defines the observed state of Gateway.
 type GatewayStatus struct {
 	// Conditions describe the current conditions of the Gateway.
-	Conditions []GatewayCondition `json:"conditions" protobuf:"bytes,1,rep,name=conditions"`
+	// +optional
+	Conditions []GatewayCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 	// Listeners provide status for each listener defined in the Spec. The name
 	// in ListenerStatus refers to the corresponding Listener of the same name.
-	Listeners []ListenerStatus `json:"listeners" protobuf:"bytes,2,rep,name=listeners"`
+	// +optional
+	Listeners []ListenerStatus `json:"listeners,omitempty" protobuf:"bytes,2,rep,name=listeners"`
 }
 
 // GatewayConditionType is a type of condition associated with a Gateway.

--- a/api/v1alpha1/gatewayclass_types.go
+++ b/api/v1alpha1/gatewayclass_types.go
@@ -138,6 +138,7 @@ type GatewayClassConditionStatus = core.ConditionStatus
 type GatewayClassStatus struct {
 	// Conditions is the current status from the controller for
 	// this GatewayClass.
+	// +optional
 	// +kubebuilder:default={{type: "InvalidParameters", status: "Unknown"}}
 	Conditions []GatewayClassCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 }

--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -195,6 +195,7 @@ message GatewayClassSpec {
 message GatewayClassStatus {
   // Conditions is the current status from the controller for
   // this GatewayClass.
+  // +optional
   // +kubebuilder:default={{type: "InvalidParameters", status: "Unknown"}}
   repeated GatewayClassCondition conditions = 1;
 }
@@ -279,10 +280,12 @@ message GatewaySpec {
 // GatewayStatus defines the observed state of Gateway.
 message GatewayStatus {
   // Conditions describe the current conditions of the Gateway.
+  // +optional
   repeated GatewayCondition conditions = 1;
 
   // Listeners provide status for each listener defined in the Spec. The name
   // in ListenerStatus refers to the corresponding Listener of the same name.
+  // +optional
   repeated ListenerStatus listeners = 2;
 }
 

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -401,9 +401,6 @@ spec:
                   - name
                   type: object
                 type: array
-            required:
-            - conditions
-            - listeners
             type: object
         type: object
     served: true


### PR DESCRIPTION
1. Make GatewayStatus.Conditions and GatewayStatus.Listeners optional fields as discussed here: https://github.com/kubernetes-sigs/service-apis/issues/174#issuecomment-624952923