### PR TITLE
Singularizes example HTTPRoute hostname

### DIFF
--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -34,8 +34,7 @@ metadata:
     app: foo
 spec:
   hosts:
-    - hostnames:
-        - "foo.com"
+    - hostname: "foo.com"
       rules:
         - match:
             path: /bar


### PR DESCRIPTION
https://github.com/kubernetes-sigs/service-apis/pull/43 singularized the HTTPRoute hostname field. This PR updates the example accordingly.

/assign @bowei 
/cc @robscott 