### PR TITLE
Adding new status conditions covering forbidden namespaces

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -352,6 +352,9 @@ const (
 	// ConditionNoSuchGatewayClass indicates that the specified GatewayClass
 	// does not exist.
 	ConditionNoSuchGatewayClass GatewayConditionType = "NoSuchGatewayClass"
+	// ConditionForbiddenNamespaceForClass indicates that this Gateway is in
+	// a namespace forbidden by the GatewayClass.
+	ConditionForbiddenNamespaceForClass GatewayConditionType = "ForbiddenNamespaceForClass"
 	// ConditionGatewayNotScheduled indicates that the Gateway has not been
 	// scheduled.
 	ConditionGatewayNotScheduled GatewayConditionType = "GatewayNotScheduled"
@@ -371,6 +374,9 @@ const (
 	// ConditionInvalidRoutes indicates that at least one of the specified
 	// routes is invalid.
 	ConditionInvalidRoutes GatewayConditionType = "InvalidRoutes"
+	// ConditionForbiddenRoutesForClass indicates that at least one of the
+	// routes is in a namespace forbidden by the GatewayClass.
+	ConditionForbiddenRoutesForClass GatewayConditionType = "ForbiddenRoutesForClass"
 )
 
 // GatewayCondition is an error status for a given route.

--- a/api/v1alpha1/gatewayclass_types.go
+++ b/api/v1alpha1/gatewayclass_types.go
@@ -73,6 +73,12 @@ type GatewayClassSpec struct {
 	// GatewayClass from any namespace. This field is intentionally not a
 	// pointer because the nil behavior (no namespaces) is undesirable here.
 	//
+	// When a Gateway attempts to use this class from a namespace that is not
+	// allowed by this selector, the controller implementing the GatewayClass
+	// may add a new "ForbiddenNamespaceForClass" condition to the Gateway
+	// status. Adding this condition is considered optional since not all
+	// controllers will have access to all namespaces.
+	//
 	// Support: Core
 	//
 	// +optional
@@ -89,6 +95,12 @@ type GatewayClassSpec struct {
 	// that Gateways can reference Routes in any namespace. This field is
 	// intentionally a pointer to support the nil behavior (only local Routes
 	// allowed).
+	//
+	// When any Routes are selected by a Gateway in a namespace that is not
+	// allowed by this selector, the controller implementing the GatewayClass
+	// may add a new "ForbiddenRoutesForClass" condition to the Gateway status.
+	// Adding this condition is considered optional since not all controllers
+	// will have access to all namespaces.
 	//
 	// Support: Core
 	//

--- a/api/v1alpha1/generated.proto
+++ b/api/v1alpha1/generated.proto
@@ -198,6 +198,12 @@ message GatewayClassSpec {
   // GatewayClass from any namespace. This field is intentionally not a
   // pointer because the nil behavior (no namespaces) is undesirable here.
   //
+  // When a Gateway attempts to use this class from a namespace that is not
+  // allowed by this selector, the controller implementing the GatewayClass
+  // may add a new "ForbiddenNamespaceForClass" condition to the Gateway
+  // status. Adding this condition is considered optional since not all
+  // controllers will have access to all namespaces.
+  //
   // Support: Core
   //
   // +optional
@@ -214,6 +220,12 @@ message GatewayClassSpec {
   // that Gateways can reference Routes in any namespace. This field is
   // intentionally a pointer to support the nil behavior (only local Routes
   // allowed).
+  //
+  // When any Routes are selected by a Gateway in a namespace that is not
+  // allowed by this selector, the controller implementing the GatewayClass
+  // may add a new "ForbiddenRoutesForClass" condition to the Gateway status.
+  // Adding this condition is considered optional since not all controllers
+  // will have access to all namespaces.
   //
   // Support: Core
   //

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -47,7 +47,12 @@ spec:
                   An empty selector (default) indicates that Gateways can use this
                   GatewayClass from any namespace. This field is intentionally not
                   a pointer because the nil behavior (no namespaces) is undesirable
-                  here. \n Support: Core"
+                  here. \n When a Gateway attempts to use this class from a namespace
+                  that is not allowed by this selector, the controller implementing
+                  the GatewayClass may add a new \"ForbiddenNamespaceForClass\" condition
+                  to the Gateway status. Adding this condition is considered optional
+                  since not all controllers will have access to all namespaces. \n
+                  Support: Core"
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.
@@ -100,7 +105,12 @@ spec:
                   reference Routes within the same namespace. An empty selector indicates
                   that Gateways can reference Routes in any namespace. This field
                   is intentionally a pointer to support the nil behavior (only local
-                  Routes allowed). \n Support: Core"
+                  Routes allowed). \n When any Routes are selected by a Gateway in
+                  a namespace that is not allowed by this selector, the controller
+                  implementing the GatewayClass may add a new \"ForbiddenRoutesForClass\"
+                  condition to the Gateway status. Adding this condition is considered
+                  optional since not all controllers will have access to all namespaces.
+                  \n Support: Core"
                 properties:
                   matchExpressions:
                     description: matchExpressions is a list of label selector requirements.

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -264,6 +264,11 @@ namespaces outside this selector.</p>
 <p>An empty selector (default) indicates that Gateways can use this
 GatewayClass from any namespace. This field is intentionally not a
 pointer because the nil behavior (no namespaces) is undesirable here.</p>
+<p>When a Gateway attempts to use this class from a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenNamespaceForClass&rdquo; condition to the Gateway
+status. Adding this condition is considered optional since not all
+controllers will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -288,6 +293,11 @@ reference Routes within the same namespace. An empty selector indicates
 that Gateways can reference Routes in any namespace. This field is
 intentionally a pointer to support the nil behavior (only local Routes
 allowed).</p>
+<p>When any Routes are selected by a Gateway in a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenRoutesForClass&rdquo; condition to the Gateway status.
+Adding this condition is considered optional since not all controllers
+will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -772,6 +782,11 @@ namespaces outside this selector.</p>
 <p>An empty selector (default) indicates that Gateways can use this
 GatewayClass from any namespace. This field is intentionally not a
 pointer because the nil behavior (no namespaces) is undesirable here.</p>
+<p>When a Gateway attempts to use this class from a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenNamespaceForClass&rdquo; condition to the Gateway
+status. Adding this condition is considered optional since not all
+controllers will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -796,6 +811,11 @@ reference Routes within the same namespace. An empty selector indicates
 that Gateways can reference Routes in any namespace. This field is
 intentionally a pointer to support the nil behavior (only local Routes
 allowed).</p>
+<p>When any Routes are selected by a Gateway in a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenRoutesForClass&rdquo; condition to the Gateway status.
+Adding this condition is considered optional since not all controllers
+will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -589,6 +589,11 @@ namespaces outside this selector.</p>
 <p>An empty selector (default) indicates that Gateways can use this
 GatewayClass from any namespace. This field is intentionally not a
 pointer because the nil behavior (no namespaces) is undesirable here.</p>
+<p>When a Gateway attempts to use this class from a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenNamespaceForClass&rdquo; condition to the Gateway
+status. Adding this condition is considered optional since not all
+controllers will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -613,6 +618,11 @@ reference Routes within the same namespace. An empty selector indicates
 that Gateways can reference Routes in any namespace. This field is
 intentionally a pointer to support the nil behavior (only local Routes
 allowed).</p>
+<p>When any Routes are selected by a Gateway in a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenRoutesForClass&rdquo; condition to the Gateway status.
+Adding this condition is considered optional since not all controllers
+will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -1097,6 +1107,11 @@ namespaces outside this selector.</p>
 <p>An empty selector (default) indicates that Gateways can use this
 GatewayClass from any namespace. This field is intentionally not a
 pointer because the nil behavior (no namespaces) is undesirable here.</p>
+<p>When a Gateway attempts to use this class from a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenNamespaceForClass&rdquo; condition to the Gateway
+status. Adding this condition is considered optional since not all
+controllers will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -1121,6 +1136,11 @@ reference Routes within the same namespace. An empty selector indicates
 that Gateways can reference Routes in any namespace. This field is
 intentionally a pointer to support the nil behavior (only local Routes
 allowed).</p>
+<p>When any Routes are selected by a Gateway in a namespace that is not
+allowed by this selector, the controller implementing the GatewayClass
+may add a new &ldquo;ForbiddenRoutesForClass&rdquo; condition to the Gateway status.
+Adding this condition is considered optional since not all controllers
+will have access to all namespaces.</p>
 <p>Support: Core</p>
 </td>
 </tr>


### PR DESCRIPTION
This standardizes the status conditions to set when the "allows" fields on GatewayClass are violated. Fixes #177. 

/cc @danehans @jpeach 