### PR TITLE
Update root object tags for API documentation.

### DIFF
--- a/api/v1alpha1/gateway_types.go
+++ b/api/v1alpha1/gateway_types.go
@@ -21,7 +21,6 @@ import (
 )
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 

--- a/api/v1alpha1/gatewayclass_types.go
+++ b/api/v1alpha1/gatewayclass_types.go
@@ -20,11 +20,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
-// +genclient
-// +genclient:nonNamespaced
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/api/v1alpha1/httproute_types.go
+++ b/api/v1alpha1/httproute_types.go
@@ -304,6 +304,7 @@ type GatewayObjectReference struct {
 	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
 }
 
+// +genclient
 // +kubebuilder:object:root=true
 
 // HTTPRoute is the Schema for the httproutes API
@@ -315,8 +316,6 @@ type HTTPRoute struct {
 	Status HTTPRouteStatus `json:"status,omitempty" protobuf:"bytes,4,opt,name=status"`
 }
 
-// +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 
 // HTTPRouteList contains a list of HTTPRoute

--- a/api/v1alpha1/tcproute_types.go
+++ b/api/v1alpha1/tcproute_types.go
@@ -35,7 +35,6 @@ type TcpRouteStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 
 // TcpRoute is the Schema for the tcproutes API

--- a/api/v1alpha1/trafficsplit_types.go
+++ b/api/v1alpha1/trafficsplit_types.go
@@ -35,7 +35,6 @@ type TrafficSplitStatus struct {
 }
 
 // +genclient
-// +genclient:Namespaced
 // +kubebuilder:object:root=true
 
 // TrafficSplit is the Schema for the trafficsplits API

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -14,6 +14,8 @@ Resource Types:
 </li><li>
 <a href="#networking.x-k8s.io/v1alpha1.GatewayClass">GatewayClass</a>
 </li><li>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute</a>
+</li><li>
 <a href="#networking.x-k8s.io/v1alpha1.TcpRoute">TcpRoute</a>
 </li><li>
 <a href="#networking.x-k8s.io/v1alpha1.TrafficSplit">TrafficSplit</a>
@@ -340,6 +342,108 @@ GatewayClassStatus
 </td>
 <td>
 <p>Status of the GatewayClass.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute
+</h3>
+<p>
+<p>HTTPRoute is the Schema for the httproutes API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+networking.x-k8s.io/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>HTTPRoute</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">
+HTTPRouteSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>hosts</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
+[]HTTPRouteHost
+</a>
+</em>
+</td>
+<td>
+<p>Hosts is a list of Host definitions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
+HTTPRouteHost
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Default is the default host to use. Default.Hostnames must
+be an empty list.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteStatus">
+HTTPRouteStatus
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>
@@ -1221,91 +1325,6 @@ remove: [&ldquo;my-header1&rdquo;, &ldquo;my-header3&rdquo;]</p>
 GET /foo HTTP/1.1
 My-Header2: DEF</p>
 <p>Support: extended?</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute
-</h3>
-<p>
-<p>HTTPRoute is the Schema for the httproutes API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">
-HTTPRouteSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>hosts</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
-[]HTTPRouteHost
-</a>
-</em>
-</td>
-<td>
-<p>Hosts is a list of Host definitions.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>default</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
-HTTPRouteHost
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Default is the default host to use. Default.Hostnames must
-be an empty list.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteStatus">
-HTTPRouteStatus
-</a>
-</em>
-</td>
-<td>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -339,6 +339,8 @@
 </li><li>
 <a href="#networking.x-k8s.io/v1alpha1.GatewayClass">GatewayClass</a>
 </li><li>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute</a>
+</li><li>
 <a href="#networking.x-k8s.io/v1alpha1.TcpRoute">TcpRoute</a>
 </li><li>
 <a href="#networking.x-k8s.io/v1alpha1.TrafficSplit">TrafficSplit</a>
@@ -665,6 +667,108 @@ GatewayClassStatus
 </td>
 <td>
 <p>Status of the GatewayClass.</p>
+</td>
+</tr>
+</tbody>
+</table>
+<h3 id="networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute
+</h3>
+<p>
+<p>HTTPRoute is the Schema for the httproutes API</p>
+</p>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
+<code>apiVersion</code></br>
+string</td>
+<td>
+<code>
+networking.x-k8s.io/v1alpha1
+</code>
+</td>
+</tr>
+<tr>
+<td>
+<code>kind</code></br>
+string
+</td>
+<td><code>HTTPRoute</code></td>
+</tr>
+<tr>
+<td>
+<code>metadata</code></br>
+<em>
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
+Kubernetes meta/v1.ObjectMeta
+</a>
+</em>
+</td>
+<td>
+Refer to the Kubernetes API documentation for the fields of the
+<code>metadata</code> field.
+</td>
+</tr>
+<tr>
+<td>
+<code>spec</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">
+HTTPRouteSpec
+</a>
+</em>
+</td>
+<td>
+<br/>
+<br/>
+<table>
+<tr>
+<td>
+<code>hosts</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
+[]HTTPRouteHost
+</a>
+</em>
+</td>
+<td>
+<p>Hosts is a list of Host definitions.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>default</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
+HTTPRouteHost
+</a>
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Default is the default host to use. Default.Hostnames must
+be an empty list.</p>
+</td>
+</tr>
+</table>
+</td>
+</tr>
+<tr>
+<td>
+<code>status</code></br>
+<em>
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteStatus">
+HTTPRouteStatus
+</a>
+</em>
+</td>
+<td>
 </td>
 </tr>
 </tbody>
@@ -1546,91 +1650,6 @@ remove: [&ldquo;my-header1&rdquo;, &ldquo;my-header3&rdquo;]</p>
 GET /foo HTTP/1.1
 My-Header2: DEF</p>
 <p>Support: extended?</p>
-</td>
-</tr>
-</tbody>
-</table>
-<h3 id="networking.x-k8s.io/v1alpha1.HTTPRoute">HTTPRoute
-</h3>
-<p>
-<p>HTTPRoute is the Schema for the httproutes API</p>
-</p>
-<table>
-<thead>
-<tr>
-<th>Field</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>
-<code>metadata</code></br>
-<em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#objectmeta-v1-meta">
-Kubernetes meta/v1.ObjectMeta
-</a>
-</em>
-</td>
-<td>
-Refer to the Kubernetes API documentation for the fields of the
-<code>metadata</code> field.
-</td>
-</tr>
-<tr>
-<td>
-<code>spec</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">
-HTTPRouteSpec
-</a>
-</em>
-</td>
-<td>
-<br/>
-<br/>
-<table>
-<tr>
-<td>
-<code>hosts</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
-[]HTTPRouteHost
-</a>
-</em>
-</td>
-<td>
-<p>Hosts is a list of Host definitions.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>default</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteHost">
-HTTPRouteHost
-</a>
-</em>
-</td>
-<td>
-<em>(Optional)</em>
-<p>Default is the default host to use. Default.Hostnames must
-be an empty list.</p>
-</td>
-</tr>
-</table>
-</td>
-</tr>
-<tr>
-<td>
-<code>status</code></br>
-<em>
-<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteStatus">
-HTTPRouteStatus
-</a>
-</em>
-</td>
-<td>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
Add a +genclient annotation to root objects that were missing it.
Remove unnecessary +genclient annotations that have no effect on
codegen.

Signed-off-by: James Peach <jpeach@vmware.com>