### PR TITLE
Expands on GatewayClass.spec.controller

### DIFF
--- a/docs-src/concepts.md
+++ b/docs-src/concepts.md
@@ -343,6 +343,29 @@ status:
     Message: "foobar" is an FooBar.
 ```
 
+### GatewayClass controller selection
+
+The `GatewayClass.spec.controller` field is used to determine whether
+or not a given `GatewayClass` is managed by the controller. The
+specifics of GatewayClass selection will depend on the controller(s)
+used in a cluster.
+
+It is RECOMMENDED that controller authors/deployments make their
+selection unique by using a domain / path combination under their
+administrative control (e.g. controller managing of all `controller`s
+starting with `acme.io` is the owner of the `acme.io` domain) to avoid
+conflicts.
+
+Controller versioning can be done by encoding the version of a
+controller into the path portion. An example scheme could be (similar
+to container URIs):
+
+```text
+acme.io/gateway:1.14   // Use version 1.14
+acme.io/gateway:1.15   // Use version 1.15
+acme.io/gateway        // Use the default version
+```
+
 ## Gateway
 
 A `Gateway` is 1:1 with the life cycle of the configuration of

--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -375,6 +375,13 @@
   
 </li>
         
+          <li class="md-nav__item">
+  <a href="#gatewayclass-controller-selection" class="md-nav__link">
+    GatewayClass controller selection
+  </a>
+  
+</li>
+        
       </ul>
     </nav>
   
@@ -717,6 +724,13 @@
           <li class="md-nav__item">
   <a href="#gatewayclass-status" class="md-nav__link">
     GatewayClass status
+  </a>
+  
+</li>
+        
+          <li class="md-nav__item">
+  <a href="#gatewayclass-controller-selection" class="md-nav__link">
+    GatewayClass controller selection
   </a>
   
 </li>
@@ -1110,6 +1124,24 @@ status:
     status: True
     Reason: BadFooBar
     Message: &quot;foobar&quot; is an FooBar.
+</code></pre>
+
+<h3 id="gatewayclass-controller-selection">GatewayClass controller selection</h3>
+<p>The <code>GatewayClass.spec.controller</code> field is used to determine whether
+or not a given <code>GatewayClass</code> is managed by the controller. The
+specifics of GatewayClass selection will depend on the controller(s)
+used in a cluster.</p>
+<p>It is RECOMMENDED that controller authors/deployments make their
+selection unique by using a domain / path combination under their
+administrative control (e.g. controller managing of all <code>controller</code>s
+starting with <code>acme.io</code> is the owner of the <code>acme.io</code> domain) to avoid
+conflicts.</p>
+<p>Controller versioning can be done by encoding the version of a
+controller into the path portion. An example scheme could be (similar
+to container URIs):</p>
+<pre><code class="text">acme.io/gateway:1.14   // Use version 1.14
+acme.io/gateway:1.15   // Use version 1.15
+acme.io/gateway        // Use the default version
 </code></pre>
 
 <h2 id="gateway_1">Gateway</h2>


### PR DESCRIPTION
Adds more details on how to interpret the controller field, give
an example around how versioning will work.

Fixes: https://github.com/kubernetes-sigs/service-apis/issues/229