### PR TITLE
Adds route resource references in example gateway manifests

### DIFF
--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -19,12 +19,13 @@ spec:
   listeners:  # Use GatewayClass defaults for listener definition.
   - protocol: HTTP
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false
       routeSelector:
         matchLabels:
-          "app": "foo"
+          app: foo
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/examples/multiple-https.yaml
+++ b/examples/multiple-https.yaml
@@ -20,6 +20,7 @@ spec:
         group: core
         name: httpbin
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false
@@ -37,6 +38,7 @@ spec:
         group: core
         name: conformance
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false

--- a/examples/multiple-tcp.yaml
+++ b/examples/multiple-tcp.yaml
@@ -2,7 +2,7 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: gateway
-  namespace: ssh-server
+  namespace: default
 spec:
   class: default-class
   addresses:
@@ -13,6 +13,7 @@ spec:
   - port: 22
     protocol: TCP
     routes:
+      resource: tcproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false
@@ -23,6 +24,7 @@ spec:
   - port: 2222
     protocol: TCP
     routes:
+      resource: tcproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false
@@ -43,6 +45,7 @@ spec:
         resource: secrets
         group: core
     routes:
+      resource: tcproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false

--- a/examples/single-http.yaml
+++ b/examples/single-http.yaml
@@ -14,6 +14,7 @@ spec:
     port: 80
     protocol: HTTP
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false

--- a/examples/wildcard-http.yaml
+++ b/examples/wildcard-http.yaml
@@ -15,6 +15,7 @@ spec:
     port: 80
     protocol: HTTP
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false

--- a/examples/wildcard-https.yaml
+++ b/examples/wildcard-https.yaml
@@ -21,6 +21,7 @@ spec:
         resource: secrets
         group: core
     routes:
+      resource: httproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false


### PR DESCRIPTION
Previously, the examples would fail to install:

```
$ make install
/Library/Developer/CommandLineTools/usr/bin/make -f kubebuilder.mk manifests
go run sigs.k8s.io/controller-tools/cmd/controller-gen "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
/Library/Developer/CommandLineTools/usr/bin/make -f kubebuilder.mk install
go run sigs.k8s.io/controller-tools/cmd/controller-gen "crd:crdVersions=v1" rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
kustomize build config/crd | kubectl apply -f -
customresourcedefinition.apiextensions.k8s.io/gatewayclasses.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/gateways.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/httproutes.networking.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/tcproutes.networking.x-k8s.io created
hack/install-examples.sh
gatewayclass.networking.x-k8s.io/acme-lb created
The Gateway "my-gateway" is invalid: spec.listeners.routes.resource: Required value
make: *** [example] Error 1
```

This is because the examples did not specify the required `resource` field. This PR adds the `resource` field and applicable value to example `Gateway`  manifests.

/assign @robscott @bowei 
/cc @Miciah @JeremyOT 