### PR TITLE
Adds required route resource type to tcp example

### DIFF
--- a/examples/basic-tcp.yaml
+++ b/examples/basic-tcp.yaml
@@ -20,6 +20,7 @@ spec:
   - protocol: TCP
     port: 8080
     routes:
+      resource: tcpproutes
       routeNamespaces:
         namespaceSelector: {}
         onlySameNamespace: false


### PR DESCRIPTION
Previously, `make install` would fail with:

```
The Gateway "my-gateway" is invalid: spec.listeners.routes.resource: Required value
make: *** [example] Error 1
```

This PR adds the required route resource type in  `examples/basic-tcp.yaml`.

/assign @robscott @bowei 
/cc @JeremyOT 