### PR TITLE
httproute: correct conformance for regex support

### DIFF
--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -637,12 +637,13 @@ message HTTPRouteMatch {
   // PathType is defines the semantics of the `Path` matcher.
   //
   // Support: core (Exact, Prefix)
-  // Support: extended (RegularExpression)
-  // Support: custom (ImplementationSpecific)
+  // Support: custom (RegularExpression, ImplementationSpecific)
   //
   // Default: "Exact"
   //
   // +optional
+  // +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression;ImplementationSpecific
+  // +kubebuilder:default=Exact
   optional string pathMatchType = 1;
 
   // Path is the value of the HTTP path as interpreted via
@@ -659,6 +660,8 @@ message HTTPRouteMatch {
   // Default: "Exact"
   //
   // +optional
+  // +kubebuilder:validation:Enum=Exact;ImplementationSpecific
+  // +kubebuilder:default=Exact
   optional string headerMatchType = 3;
 
   // Headers are the HTTP Headers to match as interpreted via

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -121,12 +121,13 @@ type HTTPRouteMatch struct {
 	// PathType is defines the semantics of the `Path` matcher.
 	//
 	// Support: core (Exact, Prefix)
-	// Support: extended (RegularExpression)
-	// Support: custom (ImplementationSpecific)
+	// Support: custom (RegularExpression, ImplementationSpecific)
 	//
 	// Default: "Exact"
 	//
 	// +optional
+	// +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression;ImplementationSpecific
+	// +kubebuilder:default=Exact
 	PathMatchType PathMatchType `json:"pathMatchType" protobuf:"bytes,1,opt,name=pathMatchType"`
 	// Path is the value of the HTTP path as interpreted via
 	// PathType.
@@ -142,6 +143,8 @@ type HTTPRouteMatch struct {
 	// Default: "Exact"
 	//
 	// +optional
+	// +kubebuilder:validation:Enum=Exact;ImplementationSpecific
+	// +kubebuilder:default=Exact
 	HeaderMatchType *string `json:"headerMatchType" protobuf:"bytes,3,opt,name=headerMatchType"`
 	// Headers are the HTTP Headers to match as interpreted via
 	// HeaderMatchType. Multiple headers are ANDed together, meaning, a request

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -179,7 +179,11 @@ spec:
                               - name
                               type: object
                             headerMatchType:
+                              default: Exact
                               description: "HeaderMatchType defines the semantics of the `Header` matcher. \n Support: core (Exact) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
+                              enum:
+                              - Exact
+                              - ImplementationSpecific
                               type: string
                             headers:
                               additionalProperties:
@@ -190,7 +194,13 @@ spec:
                               description: "Path is the value of the HTTP path as interpreted via PathType. \n Default: \"/\""
                               type: string
                             pathMatchType:
-                              description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: extended (RegularExpression) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
+                              default: Exact
+                              description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Exact\""
+                              enum:
+                              - Exact
+                              - Prefix
+                              - RegularExpression
+                              - ImplementationSpecific
                               type: string
                           required:
                           - path
@@ -349,7 +359,11 @@ spec:
                                 - name
                                 type: object
                               headerMatchType:
+                                default: Exact
                                 description: "HeaderMatchType defines the semantics of the `Header` matcher. \n Support: core (Exact) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
+                                enum:
+                                - Exact
+                                - ImplementationSpecific
                                 type: string
                               headers:
                                 additionalProperties:
@@ -360,7 +374,13 @@ spec:
                                 description: "Path is the value of the HTTP path as interpreted via PathType. \n Default: \"/\""
                                 type: string
                               pathMatchType:
-                                description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: extended (RegularExpression) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
+                                default: Exact
+                                description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Exact\""
+                                enum:
+                                - Exact
+                                - Prefix
+                                - RegularExpression
+                                - ImplementationSpecific
                                 type: string
                             required:
                             - path

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1626,8 +1626,7 @@ PathMatchType
 <em>(Optional)</em>
 <p>PathType is defines the semantics of the <code>Path</code> matcher.</p>
 <p>Support: core (Exact, Prefix)
-Support: extended (RegularExpression)
-Support: custom (ImplementationSpecific)</p>
+Support: custom (RegularExpression, ImplementationSpecific)</p>
 <p>Default: &ldquo;Exact&rdquo;</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1951,8 +1951,7 @@ PathMatchType
 <em>(Optional)</em>
 <p>PathType is defines the semantics of the <code>Path</code> matcher.</p>
 <p>Support: core (Exact, Prefix)
-Support: extended (RegularExpression)
-Support: custom (ImplementationSpecific)</p>
+Support: custom (RegularExpression, ImplementationSpecific)</p>
 <p>Default: &ldquo;Exact&rdquo;</p>
 </td>
 </tr>


### PR DESCRIPTION
Changes:
- Move regex support from extend to custom. The details in regex make it
  hard to share the support in extended or core.
- add enum based validation for match type, this can be relaxed in
future to allow for arbitrary strings
- introduce kubebuilder annotations