### PR TITLE
Add clarifications for handling unsupported features.

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -112,7 +112,11 @@ type GatewaySpec struct {
 	Addresses []GatewayAddress `json:"addresses" protobuf:"bytes,3,rep,name=addresses"`
 }
 
-// ProtocolType defines the application protocol accepted by a Listener.
+// ProtocolType defines the application protocol accepted by a
+// Listener. Implementations are not required to accept all the
+// defined protocols. If an implementation does not support a
+// specified protocol, it should raise a "ConditionUnsupportedProtocol"
+// condition for the affected Listener.
 type ProtocolType string
 
 const (
@@ -242,7 +246,8 @@ type Listener struct {
 	Protocol ProtocolType `json:"protocol,omitempty" protobuf:"bytes,3,opt,name=protocol"`
 
 	// TLS is the TLS configuration for the Listener. This field
-	// is required if the Protocol field is "HTTPS" or "TLS".
+	// is required if the Protocol field is "HTTPS" or "TLS" and
+	// ignored otherwise.
 	//
 	// Support: Core
 	//
@@ -351,6 +356,10 @@ type RouteBindingSelector struct {
 	//
 	// Resource MUST correspond to route resources that are compatible with the
 	// application protocol specified in the Listener's Protocol field.
+	//
+	// If an implementation does not support or recognize this
+	// resource type, it SHOULD raise a "ConditionInvalidRoutes"
+	// condition for the affected Listener.
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -794,7 +794,8 @@ message Listener {
   optional string protocol = 3;
 
   // TLS is the TLS configuration for the Listener. This field
-  // is required if the Protocol field is "HTTPS" or "TLS".
+  // is required if the Protocol field is "HTTPS" or "TLS" and
+  // ignored otherwise.
   //
   // Support: Core
   //
@@ -923,6 +924,10 @@ message RouteBindingSelector {
   //
   // Resource MUST correspond to route resources that are compatible with the
   // application protocol specified in the Listener's Protocol field.
+  //
+  // If an implementation does not support or recognize this
+  // resource type, it SHOULD raise a "ConditionInvalidRoutes"
+  // condition for the affected Listener.
   //
   // Support: Core
   //

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -100,7 +100,7 @@ spec:
                           description: "Group is the group of the route resource to select. Omitting the value or specifying the empty string indicates the networking.x-k8s.io API group. For example, use the following to select an HTTPRoute: \n routes:   resource: httproutes \n Otherwise, if an alternative API group is desired, specify the desired group: \n routes:   group: acme.io   resource: fooroutes \n Support: Core"
                           type: string
                         resource:
-                          description: "Resource is the API resource name of the route resource to select. \n Resource MUST correspond to route resources that are compatible with the application protocol specified in the Listener's Protocol field. \n Support: Core"
+                          description: "Resource is the API resource name of the route resource to select. \n Resource MUST correspond to route resources that are compatible with the application protocol specified in the Listener's Protocol field. \n If an implementation does not support or recognize this resource type, it SHOULD raise a \"ConditionInvalidRoutes\" condition for the affected Listener. \n Support: Core"
                           type: string
                         routeNamespaces:
                           default:
@@ -177,7 +177,7 @@ spec:
                       - resource
                       type: object
                     tls:
-                      description: "TLS is the TLS configuration for the Listener. This field is required if the Protocol field is \"HTTPS\" or \"TLS\". \n Support: Core"
+                      description: "TLS is the TLS configuration for the Listener. This field is required if the Protocol field is \"HTTPS\" or \"TLS\" and ignored otherwise. \n Support: Core"
                       properties:
                         certificateRefs:
                           description: "CertificateRefs is a list of references to Kubernetes objects that each contain an identity certificate.  The host name in a TLS SNI client hello message is used for certificate matching and route host name selection. The SNI server_name must match a route host name for the Gateway to route the TLS request.  If an entry in this list omits or specifies the empty string for both the group and the resource, the resource defaults to \"secrets\". An implementation may support other resources (for example, resource \"mycertificates\" in group \"networking.acme.io\"). \n Support: Core (Kubernetes Secrets) Support: Implementation-specific (Other resource types)"

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1991,7 +1991,8 @@ TLSConfig
 <td>
 <em>(Optional)</em>
 <p>TLS is the TLS configuration for the Listener. This field
-is required if the Protocol field is &ldquo;HTTPS&rdquo; or &ldquo;TLS&rdquo;.</p>
+is required if the Protocol field is &ldquo;HTTPS&rdquo; or &ldquo;TLS&rdquo; and
+ignored otherwise.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2182,7 +2183,11 @@ status of all such Listeners.</p>
 <a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>)
 </p>
 <p>
-<p>ProtocolType defines the application protocol accepted by a Listener.</p>
+<p>ProtocolType defines the application protocol accepted by a
+Listener. Implementations are not required to accept all the
+defined protocols. If an implementation does not support a
+specified protocol, it should raise a &ldquo;ConditionUnsupportedProtocol&rdquo;
+condition for the affected Listener.</p>
 </p>
 <h3 id="networking.x-k8s.io/v1alpha1.RouteBindingSelector">RouteBindingSelector
 </h3>
@@ -2270,6 +2275,9 @@ string
 <p>Resource is the API resource name of the route resource to select.</p>
 <p>Resource MUST correspond to route resources that are compatible with the
 application protocol specified in the Listener&rsquo;s Protocol field.</p>
+<p>If an implementation does not support or recognize this
+resource type, it SHOULD raise a &ldquo;ConditionInvalidRoutes&rdquo;
+condition for the affected Listener.</p>
 <p>Support: Core</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2316,7 +2316,8 @@ TLSConfig
 <td>
 <em>(Optional)</em>
 <p>TLS is the TLS configuration for the Listener. This field
-is required if the Protocol field is &ldquo;HTTPS&rdquo; or &ldquo;TLS&rdquo;.</p>
+is required if the Protocol field is &ldquo;HTTPS&rdquo; or &ldquo;TLS&rdquo; and
+ignored otherwise.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2507,7 +2508,11 @@ status of all such Listeners.</p>
 <a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>)
 </p>
 <p>
-<p>ProtocolType defines the application protocol accepted by a Listener.</p>
+<p>ProtocolType defines the application protocol accepted by a
+Listener. Implementations are not required to accept all the
+defined protocols. If an implementation does not support a
+specified protocol, it should raise a &ldquo;ConditionUnsupportedProtocol&rdquo;
+condition for the affected Listener.</p>
 </p>
 <h3 id="networking.x-k8s.io/v1alpha1.RouteBindingSelector">RouteBindingSelector
 </h3>
@@ -2595,6 +2600,9 @@ string
 <p>Resource is the API resource name of the route resource to select.</p>
 <p>Resource MUST correspond to route resources that are compatible with the
 application protocol specified in the Listener&rsquo;s Protocol field.</p>
+<p>If an implementation does not support or recognize this
+resource type, it SHOULD raise a &ldquo;ConditionInvalidRoutes&rdquo;
+condition for the affected Listener.</p>
 <p>Support: Core</p>
 </td>
 </tr>


### PR DESCRIPTION
Some implementations will not support all the protocols or route types
defined in the API. Add some simple guidance to make it clear that an
implementation doesn't have to support everything and can raise
conditions for cases that it doesn't support.

This updates #234 
Signed-off-by: James Peach <jpeach@vmware.com>