### PR TITLE
Mark defaulted fields as optional.

### DIFF
--- a/apis/v1alpha1/forwarding_target_types.go
+++ b/apis/v1alpha1/forwarding_target_types.go
@@ -61,6 +61,7 @@ type ForwardToTarget struct {
 	//
 	// Support: Core
 	//
+	// +optional
 	// +kubebuilder:default=1
 	Weight TargetWeight `json:"weight" protobuf:"bytes,3,opt,name=weight"`
 }

--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -204,7 +204,7 @@ type Listener struct {
 	//
 	// Support: Core
 	//
-	// +required
+	// +optional
 	// +kubebuilder:default={match: "Any"}
 	Hostname HostnameMatch `json:"hostname,omitempty" protobuf:"bytes,1,opt,name=hostname"`
 
@@ -317,8 +317,8 @@ type RouteBindingSelector struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:default={onlySameNamespace:true}
 	// +optional
+	// +kubebuilder:default={onlySameNamespace:true}
 	RouteNamespaces RouteNamespaces `json:"routeNamespaces,omitempty" protobuf:"bytes,1,opt,name=routeNamespaces"`
 	// RouteSelector specifies a set of route labels used for selecting
 	// routes to associate with the Gateway. If RouteSelector is defined,
@@ -345,6 +345,7 @@ type RouteBindingSelector struct {
 	//
 	// Support: Core
 	//
+	// +optional
 	// +kubebuilder:default=networking.x-k8s.io
 	Group string `json:"group" protobuf:"bytes,3,opt,name=group"`
 	// Resource is the API resource name of the route resource to select.

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -95,8 +95,8 @@ type GatewayClassSpec struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:default={onlySameNamespace:true}
 	// +optional
+	// +kubebuilder:default={onlySameNamespace:true}
 	AllowedRouteNamespaces RouteNamespaces `json:"allowedRouteNamespaces,omitempty" protobuf:"bytes,3,opt,name=allowedRouteNamespaces"`
 
 	// ParametersRef is a controller specific resource containing
@@ -148,8 +148,8 @@ type RouteNamespaces struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:default=true
 	// +optional
+	// +kubebuilder:default=true
 	OnlySameNamespace bool `json:"onlySameNamespace" protobuf:"bytes,2,opt,name=onlySameNamespace"`
 }
 

--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -48,6 +48,7 @@ message ConfigMapsDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=core
   optional string group = 1;
 
@@ -66,6 +67,7 @@ message ConfigMapsDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=configmaps
   optional string resource = 2;
 
@@ -120,6 +122,7 @@ message ForwardToTarget {
   //
   // Support: Core
   //
+  // +optional
   // +kubebuilder:default=1
   optional int32 weight = 3;
 }
@@ -278,8 +281,8 @@ message GatewayClassSpec {
   //
   // Support: Core
   //
-  // +kubebuilder:default={onlySameNamespace:true}
   // +optional
+  // +kubebuilder:default={onlySameNamespace:true}
   optional RouteNamespaces allowedRouteNamespaces = 3;
 
   // ParametersRef is a controller specific resource containing
@@ -756,7 +759,7 @@ message Listener {
   //
   // Support: Core
   //
-  // +required
+  // +optional
   // +kubebuilder:default={match: "Any"}
   optional HostnameMatch hostname = 1;
 
@@ -886,8 +889,8 @@ message RouteBindingSelector {
   //
   // Support: Core
   //
-  // +kubebuilder:default={onlySameNamespace:true}
   // +optional
+  // +kubebuilder:default={onlySameNamespace:true}
   optional RouteNamespaces routeNamespaces = 1;
 
   // RouteSelector specifies a set of route labels used for selecting
@@ -916,6 +919,7 @@ message RouteBindingSelector {
   //
   // Support: Core
   //
+  // +optional
   // +kubebuilder:default=networking.x-k8s.io
   optional string group = 3;
 
@@ -959,8 +963,8 @@ message RouteNamespaces {
   //
   // Support: Core
   //
-  // +kubebuilder:default=true
   // +optional
+  // +kubebuilder:default=true
   optional bool onlySameNamespace = 2;
 }
 
@@ -984,6 +988,7 @@ message SecretsDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=core
   optional string group = 1;
 
@@ -1002,6 +1007,7 @@ message SecretsDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=secrets
   optional string resource = 2;
 
@@ -1031,6 +1037,7 @@ message ServicesDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=core
   optional string group = 1;
 
@@ -1049,6 +1056,7 @@ message ServicesDefaultLocalObjectReference {
   //   resource: foos
   //   name: myfoo
   //
+  // +optional
   // +kubebuilder:default=services
   optional string resource = 2;
 

--- a/apis/v1alpha1/local_object_reference_types.go
+++ b/apis/v1alpha1/local_object_reference_types.go
@@ -35,6 +35,7 @@ type ServicesDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=core
 	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the API resource name of the referent. Omitting the value
@@ -52,6 +53,7 @@ type ServicesDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=services
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Name is the name of the referent.
@@ -80,6 +82,7 @@ type ConfigMapsDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=core
 	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the API resource name of the referent. Omitting the value
@@ -97,6 +100,7 @@ type ConfigMapsDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=configmaps
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Name is the name of the referent.
@@ -125,6 +129,7 @@ type SecretsDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=core
 	Group string `json:"group" protobuf:"bytes,1,opt,name=group"`
 	// Resource is the API resource name of the referent. Omitting the value
@@ -142,6 +147,7 @@ type SecretsDefaultLocalObjectReference struct {
 	//   resource: foos
 	//   name: myfoo
 	//
+	// +optional
 	// +kubebuilder:default=secrets
 	Resource string `json:"resource" protobuf:"bytes,2,opt,name=resource"`
 	// Name is the name of the referent.

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -120,9 +120,7 @@ spec:
                     description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                     type: string
                 required:
-                - group
                 - name
-                - resource
                 type: object
             required:
             - controller

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -173,7 +173,6 @@ spec:
                               type: object
                           type: object
                       required:
-                      - group
                       - resource
                       type: object
                     tls:
@@ -196,9 +195,7 @@ spec:
                                 description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the secrets resource. For example, use the following to specify a secrets resource: \n fooRef:   name: mysecret \n Otherwise, if the secrets resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                 type: string
                             required:
-                            - group
                             - name
-                            - resource
                             type: object
                           type: array
                         minimumVersion:

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -50,9 +50,7 @@ spec:
                         description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                         type: string
                     required:
-                    - group
                     - name
-                    - resource
                     type: object
                   hostnames:
                     description: "Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process a the request. Hostname is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: \n 1. IPs are not allowed. 2. The `:` delimiter is not respected because ports are not allowed. \n Incoming requests are matched against the hostnames before the HTTPRoute rules. If no hostname is specified, traffic is routed based on the HTTPRouteRules. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.example.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). Requests will be matched against the Host field in the following order: 1. If Host is precise, the request matches this rule if    the http host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if    the http host header is to equal to the suffix    (removing the first label) of the wildcard rule. \n Support: Core"
@@ -82,9 +80,7 @@ spec:
                                   description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                   type: string
                               required:
-                              - group
                               - name
-                              - resource
                               type: object
                             forwardTo:
                               description: "ForwardTo sends requests to the referenced object(s).  The resource may be \"services\" (omit or use the empty string for the group), or an implementation may support other resources (for example, resource \"myroutetargets\" in group \"networking.acme.io\"). Omitting or specifying the empty string for both the resource and group indicates that the resource is \"services\".  If the referent cannot be found, the \"InvalidRoutes\" status condition on any Gateway that includes the HTTPRoute will be true. \n Support: core"
@@ -110,9 +106,7 @@ spec:
                                         description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the services resource. For example, use the following to specify a services resource: \n fooRef:   name: myservice \n Otherwise, if the services resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                         type: string
                                     required:
-                                    - group
                                     - name
-                                    - resource
                                     type: object
                                   weight:
                                     default: 1
@@ -121,7 +115,6 @@ spec:
                                     type: integer
                                 required:
                                 - targetRef
-                                - weight
                                 type: object
                               type: array
                           required:
@@ -145,9 +138,7 @@ spec:
                                   description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                   type: string
                               required:
-                              - group
                               - name
-                              - resource
                               type: object
                             headers:
                               description: "Headers related filters. \n Support: extended"
@@ -185,9 +176,7 @@ spec:
                                   description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                   type: string
                               required:
-                              - group
                               - name
-                              - resource
                               type: object
                             headerMatchType:
                               description: "HeaderMatchType defines the semantics of the `Header` matcher. \n Support: core (Exact) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
@@ -231,9 +220,7 @@ spec:
                           description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                           type: string
                       required:
-                      - group
                       - name
-                      - resource
                       type: object
                     hostnames:
                       description: "Hostnames defines a set of hostname that should match against the HTTP Host header to select a HTTPRoute to process a the request. Hostname is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: \n 1. IPs are not allowed. 2. The `:` delimiter is not respected because ports are not allowed. \n Incoming requests are matched against the hostnames before the HTTPRoute rules. If no hostname is specified, traffic is routed based on the HTTPRouteRules. \n Hostname can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.example.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). Requests will be matched against the Host field in the following order: 1. If Host is precise, the request matches this rule if    the http host header is equal to Host. 2. If Host is a wildcard, then the request matches this rule if    the http host header is to equal to the suffix    (removing the first label) of the wildcard rule. \n Support: Core"
@@ -263,9 +250,7 @@ spec:
                                     description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                     type: string
                                 required:
-                                - group
                                 - name
-                                - resource
                                 type: object
                               forwardTo:
                                 description: "ForwardTo sends requests to the referenced object(s).  The resource may be \"services\" (omit or use the empty string for the group), or an implementation may support other resources (for example, resource \"myroutetargets\" in group \"networking.acme.io\"). Omitting or specifying the empty string for both the resource and group indicates that the resource is \"services\".  If the referent cannot be found, the \"InvalidRoutes\" status condition on any Gateway that includes the HTTPRoute will be true. \n Support: core"
@@ -291,9 +276,7 @@ spec:
                                           description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the services resource. For example, use the following to specify a services resource: \n fooRef:   name: myservice \n Otherwise, if the services resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                           type: string
                                       required:
-                                      - group
                                       - name
-                                      - resource
                                       type: object
                                     weight:
                                       default: 1
@@ -302,7 +285,6 @@ spec:
                                       type: integer
                                   required:
                                   - targetRef
-                                  - weight
                                   type: object
                                 type: array
                             required:
@@ -326,9 +308,7 @@ spec:
                                     description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                     type: string
                                 required:
-                                - group
                                 - name
-                                - resource
                                 type: object
                               headers:
                                 description: "Headers related filters. \n Support: extended"
@@ -366,9 +346,7 @@ spec:
                                     description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                     type: string
                                 required:
-                                - group
                                 - name
-                                - resource
                                 type: object
                               headerMatchType:
                                 description: "HeaderMatchType defines the semantics of the `Header` matcher. \n Support: core (Exact) Support: custom (ImplementationSpecific) \n Default: \"Exact\""

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -55,9 +55,7 @@ spec:
                               description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                               type: string
                           required:
-                          - group
                           - name
-                          - resource
                           type: object
                         forwardTo:
                           description: ForwardTo sends requests to the referenced object.  The resource may be "services" (omit or use the empty string for the group), or an implementation may support other resources (for example, resource "myroutetargets" in group "networking.acme.io"). Omitting or specifying the empty string for both the resource and group indicates that the resource is "services".  If the referent cannot be found, the "InvalidRoutes" status condition on any Gateway that includes the TCPRoute will be true.
@@ -81,9 +79,7 @@ spec:
                                   description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the services resource. For example, use the following to specify a services resource: \n fooRef:   name: myservice \n Otherwise, if the services resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                                   type: string
                               required:
-                              - group
                               - name
-                              - resource
                               type: object
                             weight:
                               default: 1
@@ -92,7 +88,6 @@ spec:
                               type: integer
                           required:
                           - targetRef
-                          - weight
                           type: object
                       required:
                       - forwardTo
@@ -115,9 +110,7 @@ spec:
                               description: "Resource is the API resource name of the referent. Omitting the value or specifying the empty string indicates the configmaps resource. For example, use the following to specify a configmaps resource: \n fooRef:   name: myconfigmap \n Otherwise, if the configmaps resource is not desired, specify the desired group: \n fooRef:   group: acme.io   resource: foos   name: myfoo"
                               type: string
                           required:
-                          - group
                           - name
-                          - resource
                           type: object
                       type: object
                   type: object

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -566,6 +566,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a configmaps:</p>
@@ -588,6 +589,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the configmaps resource. For
 example, use the following to specify a configmaps resource:</p>
@@ -683,6 +685,7 @@ TargetWeight
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Weight specifies the proportion of traffic to be forwarded to a targetRef,
 computed as weight/(sum of all weights in targetRefs). Weight is not a
 percentage and the sum of weights does not need to equal 100. The following
@@ -1928,6 +1931,7 @@ HostnameMatch
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Hostname specifies to match the virtual host name for
 protocol types that define this concept.</p>
 <p>Incoming requests that include a host name are matched
@@ -2246,6 +2250,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the route resource to select. Omitting the value or specifying
 the empty string indicates the networking.x-k8s.io API group.
 For example, use the following to select an HTTPRoute:</p>
@@ -2363,6 +2368,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a secrets resource:</p>
@@ -2385,6 +2391,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the secrets resource. For
 example, use the following to specify a secrets resource:</p>
@@ -2438,6 +2445,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a service:</p>
@@ -2460,6 +2468,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the services resource. For example,
 use the following to specify a services resource:</p>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -891,6 +891,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a configmaps:</p>
@@ -913,6 +914,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the configmaps resource. For
 example, use the following to specify a configmaps resource:</p>
@@ -1008,6 +1010,7 @@ TargetWeight
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Weight specifies the proportion of traffic to be forwarded to a targetRef,
 computed as weight/(sum of all weights in targetRefs). Weight is not a
 percentage and the sum of weights does not need to equal 100. The following
@@ -2253,6 +2256,7 @@ HostnameMatch
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Hostname specifies to match the virtual host name for
 protocol types that define this concept.</p>
 <p>Incoming requests that include a host name are matched
@@ -2571,6 +2575,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the route resource to select. Omitting the value or specifying
 the empty string indicates the networking.x-k8s.io API group.
 For example, use the following to select an HTTPRoute:</p>
@@ -2688,6 +2693,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a secrets resource:</p>
@@ -2710,6 +2716,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the secrets resource. For
 example, use the following to specify a secrets resource:</p>
@@ -2763,6 +2770,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Group is the group of the referent.  Omitting the value or specifying
 the empty string indicates the core API group.  For example, use the
 following to specify a service:</p>
@@ -2785,6 +2793,7 @@ string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Resource is the API resource name of the referent. Omitting the value
 or specifying the empty string indicates the services resource. For example,
 use the following to specify a services resource:</p>


### PR DESCRIPTION
Since required-ness is checked before defaulting is applied, all
defaulted fields should be optional. I also took the opportunity
to order the kubebuilder annotations consistently.

Signed-off-by: James Peach <jpeach@vmware.com>