### PR TITLE
Reorders make all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 # ROOT is the root of the mkdocs tree.
 ROOT := $(abspath $(TOP))
 
-all: controller generate verify
+all: generate controller verify
 
 # Build manager binary and run static analysis.
 .PHONY: controller


### PR DESCRIPTION
Previously, running `make all` after making a change to the API, e.g https://github.com/kubernetes-sigs/service-apis/pull/250, the command fails:

```
$ make all
/Library/Developer/CommandLineTools/usr/bin/make -f kubebuilder.mk manager
go run sigs.k8s.io/controller-tools/cmd/controller-gen object:headerFile=./hack/boilerplate.go.txt paths="./..."
go fmt ./...
go vet ./...
# sigs.k8s.io/service-apis/apis/v1alpha1
apis/v1alpha1/generated.pb.go:3098:28: m.ForwardTo.MarshalToSizedBuffer undefined (type []ForwardToTarget has no field or method MarshalToSizedBuffer)
apis/v1alpha1/generated.pb.go:4014:18: m.ForwardTo.Size undefined (type []ForwardToTarget has no field or method Size)
apis/v1alpha1/generated.pb.go:4633:48: this.ForwardTo.String undefined (type []ForwardToTarget has no field or method String)
apis/v1alpha1/generated.pb.go:10118:17: cannot use &ForwardToTarget literal (type *ForwardToTarget) as type []ForwardToTarget in assignment
apis/v1alpha1/generated.pb.go:10120:25: m.ForwardTo.Unmarshal undefined (type []ForwardToTarget has no field or method Unmarshal)
make[1]: *** [vet] Error 2
make: *** [controller] Error 2
```

This PR generates  the protos, Deepcopy funcs, CRDs, etc. before building the manager binary and running static analysis.

/assign @robscott @bowei 