### PR TITLE
Update default PathMatchType in HTTPRoute to be prefix.

### DIFF
--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -642,11 +642,11 @@ message HTTPRouteMatch {
   // Support: core (Exact, Prefix)
   // Support: custom (RegularExpression, ImplementationSpecific)
   //
-  // Default: "Exact"
+  // Default: "Prefix"
   //
   // +optional
   // +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression;ImplementationSpecific
-  // +kubebuilder:default=Exact
+  // +kubebuilder:default=Prefix
   optional string pathMatchType = 1;
 
   // Path is the value of the HTTP path as interpreted via

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -123,11 +123,11 @@ type HTTPRouteMatch struct {
 	// Support: core (Exact, Prefix)
 	// Support: custom (RegularExpression, ImplementationSpecific)
 	//
-	// Default: "Exact"
+	// Default: "Prefix"
 	//
 	// +optional
 	// +kubebuilder:validation:Enum=Exact;Prefix;RegularExpression;ImplementationSpecific
-	// +kubebuilder:default=Exact
+	// +kubebuilder:default=Prefix
 	PathMatchType PathMatchType `json:"pathMatchType" protobuf:"bytes,1,opt,name=pathMatchType"`
 	// Path is the value of the HTTP path as interpreted via
 	// PathType.

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -195,8 +195,8 @@ spec:
                               description: "Path is the value of the HTTP path as interpreted via PathType. \n Default: \"/\""
                               type: string
                             pathMatchType:
-                              default: Exact
-                              description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Exact\""
+                              default: Prefix
+                              description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Prefix\""
                               enum:
                               - Exact
                               - Prefix
@@ -376,8 +376,8 @@ spec:
                                 description: "Path is the value of the HTTP path as interpreted via PathType. \n Default: \"/\""
                                 type: string
                               pathMatchType:
-                                default: Exact
-                                description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Exact\""
+                                default: Prefix
+                                description: "PathType is defines the semantics of the `Path` matcher. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Default: \"Prefix\""
                                 enum:
                                 - Exact
                                 - Prefix

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1628,7 +1628,7 @@ PathMatchType
 <p>PathType is defines the semantics of the <code>Path</code> matcher.</p>
 <p>Support: core (Exact, Prefix)
 Support: custom (RegularExpression, ImplementationSpecific)</p>
-<p>Default: &ldquo;Exact&rdquo;</p>
+<p>Default: &ldquo;Prefix&rdquo;</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1953,7 +1953,7 @@ PathMatchType
 <p>PathType is defines the semantics of the <code>Path</code> matcher.</p>
 <p>Support: core (Exact, Prefix)
 Support: custom (RegularExpression, ImplementationSpecific)</p>
-<p>Default: &ldquo;Exact&rdquo;</p>
+<p>Default: &ldquo;Prefix&rdquo;</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This patch changes the default `PathMatchType` in `HTTPRouteMatch` from `Exact` to `Prefix`. 

This should fix #254 .