### PR TITLE
httproute: validation for matches

### DIFF
--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -718,7 +718,10 @@ message HTTPRouteRule {
   // - path prefix of `/v2/foo`
   // Please see doc for HTTPRouteMatch on how to specify multiple
   // match conditions that should be ANDed together.
-  // +optional
+  //
+  // Default catch-all route can be configured using path `/`.
+  //
+  // +kubebuilder:validation:MinItems=1
   repeated HTTPRouteMatch matches = 1;
 
   // Filter defines what filters are applied to the request.

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -96,7 +96,10 @@ type HTTPRouteRule struct {
 	// - path prefix of `/v2/foo`
 	// Please see doc for HTTPRouteMatch on how to specify multiple
 	// match conditions that should be ANDed together.
-	// +optional
+	//
+	// Default catch-all route can be configured using path `/`.
+	//
+	// +kubebuilder:validation:MinItems=1
 	Matches []HTTPRouteMatch `json:"matches" protobuf:"bytes,1,rep,name=matches"`
 	// Filter defines what filters are applied to the request.
 	// +optional

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -162,7 +162,7 @@ spec:
                                 type: object
                             type: object
                           matches:
-                            description: 'Matches define conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. For example, take the following matches configuration: matches: - path: /foo   headers:     version: "2" - path: /v2/foo For a request to match against this rule, a request should satisfy EITHER of the two conditions: - path prefixed with `/foo` AND contains the header `version: "2"` - path prefix of `/v2/foo` Please see doc for HTTPRouteMatch on how to specify multiple match conditions that should be ANDed together.'
+                            description: "Matches define conditions used for matching the rule against incoming HTTP requests. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. For example, take the following matches configuration: matches: - path: /foo   headers:     version: \"2\" - path: /v2/foo For a request to match against this rule, a request should satisfy EITHER of the two conditions: - path prefixed with `/foo` AND contains the header `version: \"2\"` - path prefix of `/v2/foo` Please see doc for HTTPRouteMatch on how to specify multiple match conditions that should be ANDed together. \n Default catch-all route can be configured using path `/`."
                             items:
                               description: 'HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied. For example:  match:    path: /foo    headers:      version: "1" will result in a match only if an HTTP request''s path starts with `/foo` AND contains the `version: "1"` header.'
                               properties:
@@ -210,7 +210,10 @@ spec:
                               required:
                               - path
                               type: object
+                            minItems: 1
                             type: array
+                        required:
+                        - matches
                         type: object
                       type: array
                   required:

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1720,7 +1720,6 @@ the request.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Matches define conditions used for matching the rule against
 incoming HTTP requests.
 Each match is independent, i.e. this rule will be matched
@@ -1737,6 +1736,7 @@ EITHER of the two conditions:
 - path prefix of <code>/v2/foo</code>
 Please see doc for HTTPRouteMatch on how to specify multiple
 match conditions that should be ANDed together.</p>
+<p>Default catch-all route can be configured using path <code>/</code>.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2045,7 +2045,6 @@ the request.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Matches define conditions used for matching the rule against
 incoming HTTP requests.
 Each match is independent, i.e. this rule will be matched
@@ -2062,6 +2061,7 @@ EITHER of the two conditions:
 - path prefix of <code>/v2/foo</code>
 Please see doc for HTTPRouteMatch on how to specify multiple
 match conditions that should be ANDed together.</p>
+<p>Default catch-all route can be configured using path <code>/</code>.</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
This commit adds a validation for minimum 1 item for the `matches` array
and also adds in comment for configuring the default route.

This is a follow up on https://github.com/kubernetes-sigs/service-apis/pull/241#issuecomment-673139234.