### PR TITLE
Fix protobuf build ordering.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,16 @@ all: generate controller verify
 controller:
 	$(MAKE) -f kubebuilder.mk manager
 
-# Run generators for protos, Deepcopy funcs, CRDs, and docs..
+# Run generators for protos, Deepcopy funcs, CRDs, and docs.
+#
+# Order here matters; we need to generate Go code before generating
+# protobuf. Generating proto is really slow, so it's last.
 .PHONY: generate
 generate:
-	$(MAKE) proto
 	$(MAKE) -f kubebuilder.mk generate
 	$(MAKE) manifests
 	$(MAKE) docs
+	$(MAKE) proto
 
 # Generate manifests e.g. CRD, RBAC etc.
 .PHONY: manifests


### PR DESCRIPTION
Generating protobuf bindings needs to run after generating deep copy code
since it needs valid Go code to process. It's also the slowest generator,
so it deserves to go last.

Signed-off-by: James Peach <jpeach@vmware.com>