### PR TITLE
httproute: make action required

### DIFF
--- a/apis/v1alpha1/generated.proto
+++ b/apis/v1alpha1/generated.proto
@@ -725,7 +725,6 @@ message HTTPRouteRule {
   optional HTTPRouteFilter filter = 2;
 
   // Action defines what happens to the request.
-  // +optional
   optional HTTPRouteAction action = 3;
 }
 
@@ -1173,8 +1172,6 @@ message TCPRouteRule {
   optional TCPRouteMatch match = 1;
 
   // Action defines what happens to the connection.
-  //
-  // +optional
   optional TCPRouteAction action = 2;
 }
 

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -104,7 +104,6 @@ type HTTPRouteRule struct {
 	// +optional
 	Filter *HTTPRouteFilter `json:"filter" protobuf:"bytes,2,opt,name=filter"`
 	// Action defines what happens to the request.
-	// +optional
 	Action *HTTPRouteAction `json:"action" protobuf:"bytes,3,opt,name=action"`
 }
 

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -49,8 +49,6 @@ type TCPRouteRule struct {
 	// +optional
 	Match *TCPRouteMatch `json:"match" protobuf:"bytes,1,opt,name=match"`
 	// Action defines what happens to the connection.
-	//
-	// +optional
 	Action *TCPRouteAction `json:"action" protobuf:"bytes,2,opt,name=action"`
 }
 

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -211,6 +211,8 @@ spec:
                               - path
                               type: object
                             type: array
+                        required:
+                        - action
                         type: object
                       minItems: 1
                       type: array

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -117,6 +117,8 @@ spec:
                           - name
                           type: object
                       type: object
+                  required:
+                  - action
                   type: object
                 type: array
             required:

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1770,7 +1770,6 @@ HTTPRouteAction
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Action defines what happens to the request.</p>
 </td>
 </tr>
@@ -2697,7 +2696,6 @@ TCPRouteAction
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Action defines what happens to the connection.</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2095,7 +2095,6 @@ HTTPRouteAction
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Action defines what happens to the request.</p>
 </td>
 </tr>
@@ -3022,7 +3021,6 @@ TCPRouteAction
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Action defines what happens to the connection.</p>
 </td>
 </tr>


### PR DESCRIPTION
This commit makes action inside httproute required.
This follows
TCPRoute's action is already a required field.

In future, this condition can be relaxed if there is a need.

See #269