### PR TITLE
Add back kustomize support

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- bases/networking.x-k8s.io_gatewayclasses.yaml
+- bases/networking.x-k8s.io_gateways.yaml
+- bases/networking.x-k8s.io_httproutes.yaml
+- bases/networking.x-k8s.io_tcproutes.yaml


### PR DESCRIPTION
This was removed in
https://github.com/kubernetes-sigs/service-apis/pull/274.

This breaks 1 line installation of CRDs used by a few demos already like
`kubectl apply -k 'github.com/kubernetes-sigs/service-apis/config/crd'`