### PR TITLE
Updating ParametersRef docs and examples to be cluster-scoped

### DIFF
--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -97,9 +97,12 @@ type GatewayClassSpec struct {
 	// +kubebuilder:default={onlySameNamespace:true}
 	AllowedRouteNamespaces RouteNamespaces `json:"allowedRouteNamespaces,omitempty"`
 
-	// ParametersRef is a controller-specific resource containing the configuration
-	// parameters corresponding to this class. This is optional if the controller
-	// does not require any additional configuration.
+	// ParametersRef is a controller-specific resource containing the
+	// configuration parameters corresponding to this class. This is optional if
+	// the controller does not require any additional configuration.
+	//
+	// Parameters resources are implementation specific custom resources. These
+	// resources must be cluster-scoped.
 	//
 	// If the referent cannot be found, the GatewayClass's "InvalidParameters"
 	// status condition will be true.
@@ -144,8 +147,8 @@ type RouteNamespaces struct {
 	OnlySameNamespace bool `json:"onlySameNamespace"`
 }
 
-// GatewayClassParametersObjectReference identifies a parameters object for a
-// gateway class within a known namespace.
+// GatewayClassParametersObjectReference identifies a cluster-scoped parameters
+// resource for a GatewayClass.
 //
 // +k8s:deepcopy-gen=false
 type GatewayClassParametersObjectReference = LocalObjectReference

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -106,7 +106,7 @@ spec:
                 description: "Controller is a domain/path string that indicates the controller that is managing Gateways of this class. \n Example: \"acme.io/gateway-controller\". \n This field is not mutable and cannot be empty. \n The format of this field is DOMAIN \"/\" PATH, where DOMAIN and PATH are valid Kubernetes names (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names). \n Support: Core"
                 type: string
               parametersRef:
-                description: "ParametersRef is a controller-specific resource containing the configuration parameters corresponding to this class. This is optional if the controller does not require any additional configuration. \n If the referent cannot be found, the GatewayClass's \"InvalidParameters\" status condition will be true. \n Support: Custom"
+                description: "ParametersRef is a controller-specific resource containing the configuration parameters corresponding to this class. This is optional if the controller does not require any additional configuration. \n Parameters resources are implementation specific custom resources. These resources must be cluster-scoped. \n If the referent cannot be found, the GatewayClass's \"InvalidParameters\" status condition will be true. \n Support: Custom"
                 properties:
                   group:
                     description: Group is the API group name of the referent.

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -309,9 +309,11 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>ParametersRef is a controller-specific resource containing the configuration
-parameters corresponding to this class. This is optional if the controller
-does not require any additional configuration.</p>
+<p>ParametersRef is a controller-specific resource containing the
+configuration parameters corresponding to this class. This is optional if
+the controller does not require any additional configuration.</p>
+<p>Parameters resources are implementation specific custom resources. These
+resources must be cluster-scoped.</p>
 <p>If the referent cannot be found, the GatewayClass&rsquo;s &ldquo;InvalidParameters&rdquo;
 status condition will be true.</p>
 <p>Support: Custom</p>
@@ -848,9 +850,11 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>ParametersRef is a controller-specific resource containing the configuration
-parameters corresponding to this class. This is optional if the controller
-does not require any additional configuration.</p>
+<p>ParametersRef is a controller-specific resource containing the
+configuration parameters corresponding to this class. This is optional if
+the controller does not require any additional configuration.</p>
+<p>Parameters resources are implementation specific custom resources. These
+resources must be cluster-scoped.</p>
 <p>If the referent cannot be found, the GatewayClass&rsquo;s &ldquo;InvalidParameters&rdquo;
 status condition will be true.</p>
 <p>Support: Custom</p>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -634,9 +634,11 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>ParametersRef is a controller-specific resource containing the configuration
-parameters corresponding to this class. This is optional if the controller
-does not require any additional configuration.</p>
+<p>ParametersRef is a controller-specific resource containing the
+configuration parameters corresponding to this class. This is optional if
+the controller does not require any additional configuration.</p>
+<p>Parameters resources are implementation specific custom resources. These
+resources must be cluster-scoped.</p>
 <p>If the referent cannot be found, the GatewayClass&rsquo;s &ldquo;InvalidParameters&rdquo;
 status condition will be true.</p>
 <p>Support: Custom</p>
@@ -1173,9 +1175,11 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>ParametersRef is a controller-specific resource containing the configuration
-parameters corresponding to this class. This is optional if the controller
-does not require any additional configuration.</p>
+<p>ParametersRef is a controller-specific resource containing the
+configuration parameters corresponding to this class. This is optional if
+the controller does not require any additional configuration.</p>
+<p>Parameters resources are implementation specific custom resources. These
+resources must be cluster-scoped.</p>
 <p>If the referent cannot be found, the GatewayClass&rsquo;s &ldquo;InvalidParameters&rdquo;
 status condition will be true.</p>
 <p>Support: Custom</p>

--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   controller: acme.io/gateway-controller
   parametersRef:
-    name: acme-lb-configmap
-    group: core
-    resource: configmaps
+    name: acme-lb
+    group: acme.io
+    resource: parameters
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/examples/basic-tcp.yaml
+++ b/examples/basic-tcp.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   controller: acme.io/gateway-controller
   parametersRef:
-    name: acme-lb-configmap
-    group: core
-    resource: configmaps
+    name: acme-lb
+    group: acme.io
+    resource: parameters
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1

--- a/examples/http-trafficsplit.yaml
+++ b/examples/http-trafficsplit.yaml
@@ -5,9 +5,9 @@ metadata:
 spec: 
   controller: acme.io/gateway-controller
   parametersRef:
-    group: networking.acme.io
-    resource: AcmeLBConfig
-    name: acme-lb-config
+    name: acme-lb
+    group: acme.io
+    resource: parameters
 ---
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1


### PR DESCRIPTION
This matches the scoping of the GatewayClass and matches the intention of parameters being configured with implementation specific custom resources.

Fixes https://github.com/kubernetes-sigs/service-apis/issues/144

/cc @jpeach @hbagdi 