### PR TITLE
Make CertificateRefs field in TLSConfig optional instead of repeated.

### DIFF
--- a/apis/v1alpha1/tlsconfig_types.go
+++ b/apis/v1alpha1/tlsconfig_types.go
@@ -37,7 +37,7 @@ type TLSConfig struct {
 	// Support: Core (Kubernetes Secrets)
 	// Support: Implementation-specific (Other resource types)
 	//
-	// +required
+	// +optional
 	CertificateRefs []CertificateObjectReference `json:"certificateRefs,omitempty"`
 	// Options are a list of key/value pairs to give extended options
 	// to the provider.

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -3094,6 +3094,7 @@ appropriate when the route is modified.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>CertificateRefs is a list of references to Kubernetes objects that each
 contain an identity certificate.  The host name in a TLS SNI client hello
 message is used for certificate matching and route host name selection.

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -3419,6 +3419,7 @@ appropriate when the route is modified.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>CertificateRefs is a list of references to Kubernetes objects that each
 contain an identity certificate.  The host name in a TLS SNI client hello
 message is used for certificate matching and route host name selection.


### PR DESCRIPTION
An implementation may not have any SSL certificate as Kubernetes resource but, for example, use named certificate specified via Options field.