### PR TITLE
Changing Gateway.Class to Gateway.GatewayClassName

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -50,8 +50,9 @@ type GatewayList struct {
 // webhook, but there are many cases that will require asynchronous
 // signaling via the GatewayStatus block.
 type GatewaySpec struct {
-	// Class used for this Gateway. This is the name of a GatewayClass resource.
-	Class string `json:"class"`
+	// GatewayClassName used for this Gateway. This is the name of a
+	// GatewayClass resource.
+	GatewayClassName string `json:"gatewayClassName"`
 
 	// Listeners associated with this Gateway. Listeners define
 	// logical endpoints that are bound on this Gateway's addresses.

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -51,8 +51,8 @@ spec:
                   - value
                   type: object
                 type: array
-              class:
-                description: Class used for this Gateway. This is the name of a GatewayClass resource.
+              gatewayClassName:
+                description: GatewayClassName used for this Gateway. This is the name of a GatewayClass resource.
                 type: string
               listeners:
                 description: "Listeners associated with this Gateway. Listeners define logical endpoints that are bound on this Gateway's addresses. At least one Listener MUST be specified. \n Each Listener in this array must have a unique Port field, however a GatewayClass may collapse compatible Listener definitions into a single implementation-defined acceptor configuration even if their Port fields would otherwise conflict. \n Listeners are compatible if all of the following conditions are true: \n 1. all their Protocol fields are \"HTTP\", or all their Protocol fields are \"HTTPS\" or TLS\" 2. their Hostname fields are specified with a match type other than \"Any\" 3. their Hostname fields are not an exact match for any other Listener \n As a special case, each group of compatible listeners may contain exactly one Listener with a match type of \"Any\". \n If the GatewayClass collapses compatible Listeners, the hostname provided in the incoming client request MUST be matched to a Listener to find the correct set of Routes. The incoming hostname MUST be matched using the Hostname field for each Listener in order of most to least specific. That is, \"Exact\" matches must be processed before \"Domain\" matches, which must be processed before \"Any\" matches. \n If this field specifies multiple Listeners that have the same Port value but are not compatible, the GatewayClass must raise a \"PortConflict\" condition on the Gateway. \n Support: Core"
@@ -212,7 +212,7 @@ spec:
                 minItems: 1
                 type: array
             required:
-            - class
+            - gatewayClassName
             - listeners
             type: object
           status:

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -78,13 +78,14 @@ GatewaySpec
 <table>
 <tr>
 <td>
-<code>class</code></br>
+<code>gatewayClassName</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Class used for this Gateway. This is the name of a GatewayClass resource.</p>
+<p>GatewayClassName used for this Gateway. This is the name of a
+GatewayClass resource.</p>
 </td>
 </tr>
 <tr>
@@ -1190,13 +1191,14 @@ signaling via the GatewayStatus block.</p>
 <tbody>
 <tr>
 <td>
-<code>class</code></br>
+<code>gatewayClassName</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Class used for this Gateway. This is the name of a GatewayClass resource.</p>
+<p>GatewayClassName used for this Gateway. This is the name of a
+GatewayClass resource.</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -403,13 +403,14 @@ GatewaySpec
 <table>
 <tr>
 <td>
-<code>class</code></br>
+<code>gatewayClassName</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Class used for this Gateway. This is the name of a GatewayClass resource.</p>
+<p>GatewayClassName used for this Gateway. This is the name of a
+GatewayClass resource.</p>
 </td>
 </tr>
 <tr>
@@ -1515,13 +1516,14 @@ signaling via the GatewayStatus block.</p>
 <tbody>
 <tr>
 <td>
-<code>class</code></br>
+<code>gatewayClassName</code></br>
 <em>
 string
 </em>
 </td>
 <td>
-<p>Class used for this Gateway. This is the name of a GatewayClass resource.</p>
+<p>GatewayClassName used for this Gateway. This is the name of a
+GatewayClass resource.</p>
 </td>
 </tr>
 <tr>

--- a/examples/basic-http.yaml
+++ b/examples/basic-http.yaml
@@ -15,7 +15,7 @@ metadata:
   name: my-gateway
   namespace: default
 spec:
-  class: acme-lb
+  gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
   - protocol: HTTP
     routes:

--- a/examples/basic-tcp.yaml
+++ b/examples/basic-tcp.yaml
@@ -15,7 +15,7 @@ metadata:
   name: my-gateway
   namespace: default
 spec:
-  class: acme-lb
+  gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
   - protocol: TCP
     port: 8080

--- a/examples/default-match-http.yaml
+++ b/examples/default-match-http.yaml
@@ -13,7 +13,7 @@ metadata:
   name: default-match-gw
   namespace: default
 spec:
-  class: default-match-example
+  gatewayClassName: default-match-example
   listeners:
   - protocol: HTTP
     routes:

--- a/examples/http-trafficsplit.yaml
+++ b/examples/http-trafficsplit.yaml
@@ -15,7 +15,7 @@ metadata:
   name: my-trafficsplit-gateway
   namespace: default
 spec:
-  class: trafficsplit-lb
+  gatewayClassName: trafficsplit-lb
   listeners:  # Use GatewayClass defaults for listener definition.
     - protocol: HTTP
       routes:

--- a/examples/multiple-https.yaml
+++ b/examples/multiple-https.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway
   namespace: default
 spec:
-  class: default-class
+  gatewayClassName: default-class
   addresses:
   - type: NamedAddress
     value: auto-assign

--- a/examples/multiple-tcp.yaml
+++ b/examples/multiple-tcp.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway
   namespace: default
 spec:
-  class: default-class
+  gatewayClassName: default-class
   addresses:
   - type: NamedAddress
     value: auto-assign

--- a/examples/single-http.yaml
+++ b/examples/single-http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway
   namespace: default
 spec:
-  class: default-class
+  gatewayClassName: default-class
   addresses:
   - type: NamedAddress
     value: auto-assign

--- a/examples/wildcard-http.yaml
+++ b/examples/wildcard-http.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway
   namespace: default
 spec:
-  class: default-class
+  gatewayClassName: default-class
   addresses:
   - type: NamedAddress
     value: auto-assign

--- a/examples/wildcard-https.yaml
+++ b/examples/wildcard-https.yaml
@@ -4,7 +4,7 @@ metadata:
   name: gateway
   namespace: default
 spec:
-  class: default-class
+  gatewayClassName: default-class
   addresses:
   - type: NamedAddress
     value: auto-assign


### PR DESCRIPTION
This matches the corresponding naming on Ingress and PersistentVolume resources.