### PR TITLE
Fixing default value for GatewayClass conditions

### DIFF
--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -40,7 +40,7 @@ type GatewayClass struct {
 	// Spec for this GatewayClass.
 	Spec GatewayClassSpec `json:"spec,omitempty"`
 	// Status of the GatewayClass.
-	// +kubebuilder:default={conditions: {{type: "InvalidParameters", status: "Unknown"}}}
+	// +kubebuilder:default={conditions: {{type: "InvalidParameters", status: "Unknown", message: "Waiting for controller", reason: "Waiting", lastTransitionTime: "1970-01-01T00:00:00Z"}}}
 	Status GatewayClassStatus `json:"status,omitempty"`
 }
 
@@ -172,7 +172,7 @@ type GatewayClassStatus struct {
 	// Conditions is the current status from the controller for
 	// this GatewayClass.
 	// +optional
-	// +kubebuilder:default={{type: "InvalidParameters", status: "Unknown"}}
+	// +kubebuilder:default={{type: "InvalidParameters", status: "Unknown", message: "Waiting for controller", reason: "Waiting", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -128,13 +128,19 @@ spec:
           status:
             default:
               conditions:
-              - status: Unknown
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: Waiting
+                status: Unknown
                 type: InvalidParameters
             description: Status of the GatewayClass.
             properties:
               conditions:
                 default:
-                - status: Unknown
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: Waiting
+                  status: Unknown
                   type: InvalidParameters
                 description: Conditions is the current status from the controller for this GatewayClass.
                 items:


### PR DESCRIPTION
With the transition to the metav1.Condition type more values are required as part of a condition. The previous default value made the GatewayClass CRD invalid.

/cc @jpeach @hbagdi 