### PR TITLE
tls: make CertificateRef and Options optional

### DIFF
--- a/apis/v1alpha1/tlsconfig_types.go
+++ b/apis/v1alpha1/tlsconfig_types.go
@@ -63,7 +63,7 @@ type TLSConfig struct {
 	// Support: Core (Kubernetes Secrets)
 	// Support: Implementation-specific (Other resource types)
 	//
-	// +required
+	// +optional
 	CertificateRef CertificateObjectReference `json:"certificateRef,omitempty"`
 	// Options are a list of key/value pairs to give extended options
 	// to the provider.
@@ -74,6 +74,8 @@ type TLSConfig struct {
 	// construct.
 	//
 	// Support: Implementation-specific.
+	//
+	// +optional
 	Options map[string]string `json:"options"`
 }
 

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -207,8 +207,6 @@ spec:
                             type: string
                           description: "Options are a list of key/value pairs to give extended options to the provider. \n There variation among providers as to how ciphersuites are expressed. If there is a common subset for expressing ciphers then it will make sense to loft that as a core API construct. \n Support: Implementation-specific."
                           type: object
-                      required:
-                      - options
                       type: object
                   required:
                   - routes

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -2928,6 +2928,7 @@ SecretsDefaultLocalObjectReference
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>CertificateRef is the reference to Kubernetes object that
 contain a TLS certificate and private key.
 This certificate MUST be used for TLS handshakes for the domain
@@ -2948,6 +2949,7 @@ map[string]string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Options are a list of key/value pairs to give extended options
 to the provider.</p>
 <p>There variation among providers as to how ciphersuites are

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -3253,6 +3253,7 @@ SecretsDefaultLocalObjectReference
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>CertificateRef is the reference to Kubernetes object that
 contain a TLS certificate and private key.
 This certificate MUST be used for TLS handshakes for the domain
@@ -3273,6 +3274,7 @@ map[string]string
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Options are a list of key/value pairs to give extended options
 to the provider.</p>
 <p>There variation among providers as to how ciphersuites are


### PR DESCRIPTION
- For the "Passthrough" mode, certificateRef is not necessary as the
Gateway doesn't terminate the TLS session
- Options are meant as an extension point and should be optional.