### PR TITLE
Update Gateway condition types.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ vet:
 
 # Install CRD's and example resources to a pre-existing cluster.
 .PHONY: install
-install: manifests crd example
+install: crd example
 
 # Install the CRD's to a pre-existing cluster.
 .PHONY: crd

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -218,6 +218,13 @@ spec:
             - listeners
             type: object
           status:
+            default:
+              conditions:
+              - lastTransitionTime: "1970-01-01T00:00:00Z"
+                message: Waiting for controller
+                reason: NotReconciled
+                status: "False"
+                type: Scheduled
             description: GatewayStatus defines the observed state of Gateway.
             properties:
               addresses:
@@ -240,7 +247,13 @@ spec:
                   type: object
                 type: array
               conditions:
-                description: Conditions describe the current conditions of the Gateway.
+                default:
+                - lastTransitionTime: "1970-01-01T00:00:00Z"
+                  message: Waiting for controller
+                  reason: NotReconciled
+                  status: "False"
+                  type: Scheduled
+                description: "Conditions describe the current conditions of the Gateway. \n Implementations should prefer to express Gateway conditions using the `GatewayConditionType` and `GatewayConditionReason` constants so that operators and tools can converge on a common vocabulary to describe Gateway state. \n Known condition types are: \n * \"Scheduled\" * \"Ready\""
                 items:
                   description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, type FooStatus struct{     // Represents the observations of a foo's current state.     // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"     // +patchMergeKey=type     // +patchStrategy=merge     // +listType=map     // +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n     // other fields }"
                   properties:
@@ -283,6 +296,9 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               listeners:
                 description: Listeners provide status for each unique listener port defined in the Spec.
                 items:
@@ -340,8 +356,6 @@ spec:
                   - port
                   type: object
                 type: array
-            required:
-            - addresses
             type: object
         type: object
     served: true

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -896,6 +896,12 @@ this GatewayClass.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="networking.x-k8s.io/v1alpha1.GatewayConditionReason">GatewayConditionReason
+(<code>string</code> alias)</p></h3>
+<p>
+<p>GatewayConditionReason defines the set of reasons that explain
+why a particular Gateway condition type has been raised.</p>
+</p>
 <h3 id="networking.x-k8s.io/v1alpha1.GatewayConditionType">GatewayConditionType
 (<code>string</code> alias)</p></h3>
 <p>
@@ -1069,6 +1075,7 @@ GatewayAddress that it assigns to the Gateway.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Addresses lists the IP addresses that have actually been
 bound to the Gateway. These addresses may differ from the
 addresses in the Spec, e.g. if the Gateway automatically
@@ -1086,8 +1093,16 @@ assigns an address from a reserved pool.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Conditions describe the current conditions of the Gateway.</p>
+<p>Implementations should prefer to express Gateway conditions
+using the <code>GatewayConditionType</code> and <code>GatewayConditionReason</code>
+constants so that operators and tools can converge on a common
+vocabulary to describe Gateway state.</p>
+<p>Known condition types are:</p>
+<ul>
+<li>&ldquo;Scheduled&rdquo;</li>
+<li>&ldquo;Ready&rdquo;</li>
+</ul>
 </td>
 </tr>
 <tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1221,6 +1221,12 @@ this GatewayClass.</p>
 </tr>
 </tbody>
 </table>
+<h3 id="networking.x-k8s.io/v1alpha1.GatewayConditionReason">GatewayConditionReason
+(<code>string</code> alias)</p></h3>
+<p>
+<p>GatewayConditionReason defines the set of reasons that explain
+why a particular Gateway condition type has been raised.</p>
+</p>
 <h3 id="networking.x-k8s.io/v1alpha1.GatewayConditionType">GatewayConditionType
 (<code>string</code> alias)</p></h3>
 <p>
@@ -1394,6 +1400,7 @@ GatewayAddress that it assigns to the Gateway.</p>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Addresses lists the IP addresses that have actually been
 bound to the Gateway. These addresses may differ from the
 addresses in the Spec, e.g. if the Gateway automatically
@@ -1411,8 +1418,16 @@ assigns an address from a reserved pool.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Conditions describe the current conditions of the Gateway.</p>
+<p>Implementations should prefer to express Gateway conditions
+using the <code>GatewayConditionType</code> and <code>GatewayConditionReason</code>
+constants so that operators and tools can converge on a common
+vocabulary to describe Gateway state.</p>
+<p>Known condition types are:</p>
+<ul>
+<li>&ldquo;Scheduled&rdquo;</li>
+<li>&ldquo;Ready&rdquo;</li>
+</ul>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Update the condition types and reasons for the Gateway condition type.
Gateways should now expose their state using the `Scheduled` and `Ready`
conditions, providing additional information in the reason.

See conditions vocabulary doc: https://docs.google.com/document/d/17WGAL5jjjGHsmDCeMstZ3L5fFp6QGPHrIplQ9LPZ91k

/cc @robscott @danehans @hbagdi 