### PR TITLE
Unrevert client generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ generate:
 		output:crd:artifacts:config=config/crd/bases \
 		paths=./...
 	$(MAKE) docs
+	hack/update-codegen.sh
 
 # Run go fmt against code
 fmt:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+go install k8s.io/code-generator/cmd/{client-gen,lister-gen,informer-gen,deepcopy-gen,register-gen}
+
+# Go installs the above commands to get installed in $GOBIN if defined, and $GOPATH/bin otherwise:
+GOBIN="$(go env GOBIN)"
+gobin="${GOBIN:-$(go env GOPATH)/bin}"
+
+OUTPUT_PKG=sigs.k8s.io/service-apis/pkg/client
+FQ_APIS=sigs.k8s.io/service-apis/apis/v1alpha1
+APIS_PKG=sigs.k8s.io/service-apis
+CLIENTSET_NAME=versioned
+CLIENTSET_PKG_NAME=clientset
+
+if [[ "${VERIFY_CODEGEN:-}" == "true" ]]; then
+  echo "Running in verification mode"
+  VERIFY_FLAG="--verify-only"
+fi
+COMMON_FLAGS="${VERIFY_FLAG:-} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt"
+
+echo "Generating deepcopy funcs"
+"${gobin}/deepcopy-gen" --input-dirs "${FQ_APIS}" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" ${COMMON_FLAGS}
+
+echo "Generating clientset at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}"
+"${gobin}/client-gen" --clientset-name "${CLIENTSET_NAME}" --input-base "" --input "${FQ_APIS}" --output-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}" ${COMMON_FLAGS}
+
+echo "Generating listers at ${OUTPUT_PKG}/listers"
+"${gobin}/lister-gen" --input-dirs "${FQ_APIS}" --output-package "${OUTPUT_PKG}/listers" ${COMMON_FLAGS}
+
+echo "Generating informers at ${OUTPUT_PKG}/informers"
+"${gobin}/informer-gen" \
+         --input-dirs "${FQ_APIS}" \
+         --versioned-clientset-package "${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}/${CLIENTSET_NAME}" \
+         --listers-package "${OUTPUT_PKG}/listers" \
+         --output-package "${OUTPUT_PKG}/informers" \
+         ${COMMON_FLAGS}
+
+echo "Generating register at ${FQ_APIS}"
+"${gobin}/register-gen" --output-package "${FQ_APIS}" --input-dirs ${FQ_APIS} ${COMMON_FLAGS}

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/apis_client.go
@@ -29,6 +29,7 @@ type NetworkingV1alpha1Interface interface {
 	GatewayClassesGetter
 	HTTPRoutesGetter
 	TCPRoutesGetter
+	TLSRoutesGetter
 	UDPRoutesGetter
 }
 
@@ -51,6 +52,10 @@ func (c *NetworkingV1alpha1Client) HTTPRoutes(namespace string) HTTPRouteInterfa
 
 func (c *NetworkingV1alpha1Client) TCPRoutes(namespace string) TCPRouteInterface {
 	return newTCPRoutes(c, namespace)
+}
+
+func (c *NetworkingV1alpha1Client) TLSRoutes(namespace string) TLSRouteInterface {
+	return newTLSRoutes(c, namespace)
 }
 
 func (c *NetworkingV1alpha1Client) UDPRoutes(namespace string) UDPRouteInterface {

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/fake/fake_apis_client.go
@@ -43,6 +43,10 @@ func (c *FakeNetworkingV1alpha1) TCPRoutes(namespace string) v1alpha1.TCPRouteIn
 	return &FakeTCPRoutes{c, namespace}
 }
 
+func (c *FakeNetworkingV1alpha1) TLSRoutes(namespace string) v1alpha1.TLSRouteInterface {
+	return &FakeTLSRoutes{c, namespace}
+}
+
 func (c *FakeNetworkingV1alpha1) UDPRoutes(namespace string) v1alpha1.UDPRouteInterface {
 	return &FakeUDPRoutes{c, namespace}
 }

--- a/pkg/client/clientset/versioned/typed/apis/v1alpha1/generated_expansion.go
+++ b/pkg/client/clientset/versioned/typed/apis/v1alpha1/generated_expansion.go
@@ -25,4 +25,6 @@ type HTTPRouteExpansion interface{}
 
 type TCPRouteExpansion interface{}
 
+type TLSRouteExpansion interface{}
+
 type UDPRouteExpansion interface{}

--- a/pkg/client/informers/externalversions/apis/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/apis/v1alpha1/interface.go
@@ -31,6 +31,8 @@ type Interface interface {
 	HTTPRoutes() HTTPRouteInformer
 	// TCPRoutes returns a TCPRouteInformer.
 	TCPRoutes() TCPRouteInformer
+	// TLSRoutes returns a TLSRouteInformer.
+	TLSRoutes() TLSRouteInformer
 	// UDPRoutes returns a UDPRouteInformer.
 	UDPRoutes() UDPRouteInformer
 }
@@ -64,6 +66,11 @@ func (v *version) HTTPRoutes() HTTPRouteInformer {
 // TCPRoutes returns a TCPRouteInformer.
 func (v *version) TCPRoutes() TCPRouteInformer {
 	return &tCPRouteInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
+}
+
+// TLSRoutes returns a TLSRouteInformer.
+func (v *version) TLSRoutes() TLSRouteInformer {
+	return &tLSRouteInformer{factory: v.factory, namespace: v.namespace, tweakListOptions: v.tweakListOptions}
 }
 
 // UDPRoutes returns a UDPRouteInformer.

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -60,6 +60,8 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1alpha1().HTTPRoutes().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("tcproutes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1alpha1().TCPRoutes().Informer()}, nil
+	case v1alpha1.SchemeGroupVersion.WithResource("tlsroutes"):
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1alpha1().TLSRoutes().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("udproutes"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().V1alpha1().UDPRoutes().Informer()}, nil
 

--- a/pkg/client/listers/apis/v1alpha1/expansion_generated.go
+++ b/pkg/client/listers/apis/v1alpha1/expansion_generated.go
@@ -45,6 +45,14 @@ type TCPRouteListerExpansion interface{}
 // TCPRouteNamespaceLister.
 type TCPRouteNamespaceListerExpansion interface{}
 
+// TLSRouteListerExpansion allows custom methods to be added to
+// TLSRouteLister.
+type TLSRouteListerExpansion interface{}
+
+// TLSRouteNamespaceListerExpansion allows custom methods to be added to
+// TLSRouteNamespaceLister.
+type TLSRouteNamespaceListerExpansion interface{}
+
 // UDPRouteListerExpansion allows custom methods to be added to
 // UDPRouteLister.
 type UDPRouteListerExpansion interface{}


### PR DESCRIPTION
This was reverted in a16ebea. This PR copies the update-codegen.sh
script from prior to that commit without modification, adds it to `make
generate`, and runs it.