### PR TITLE
Make HTTPRouteFilter types optional

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -335,9 +335,11 @@ type HTTPRouteFilter struct {
 
 	// Filter-specific configuration definitions for core and extended filters
 
-	RequestHeader *HTTPRequestHeaderFilter `json:"requestHeader"`
+	// +optional
+	RequestHeader *HTTPRequestHeaderFilter `json:"requestHeader,omitempty"`
 
-	RequestMirror *HTTPRequestMirrorFilter `json:"requestMirror"`
+	// +optional
+	RequestMirror *HTTPRequestMirrorFilter `json:"requestMirror,omitempty"`
 }
 
 // HTTPRequestHeaderFilter defines configuration for the

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -134,8 +134,6 @@ spec:
                                   description: "Type identifies the filter to execute. Types are classified into three conformance-levels (similar to other locations in this API): - Core and extended: These filter types and their corresponding configuration   is defined in this package. All implementations must implement   the core filters. Implementers are encouraged to support extended filters.   Definitions for filter-specific configuration for these   filters is defined in this package. - Custom: These filters are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance rings. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ImplementationSpecific\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior."
                                   type: string
                               required:
-                              - requestHeader
-                              - requestMirror
                               - type
                               type: object
                             type: array
@@ -234,8 +232,6 @@ spec:
                                             description: "Type identifies the filter to execute. Types are classified into three conformance-levels (similar to other locations in this API): - Core and extended: These filter types and their corresponding configuration   is defined in this package. All implementations must implement   the core filters. Implementers are encouraged to support extended filters.   Definitions for filter-specific configuration for these   filters is defined in this package. - Custom: These filters are defined and supported by specific vendors.   In the future, filters showing convergence in behavior across multiple   implementations will be considered for inclusion in extended or core   conformance rings. Filter-specific configuration for such filters   is specified using the ExtensionRef field. `Type` should be set to   \"ImplementationSpecific\" for custom filters. \n Implementers are encouraged to define custom implementation types to extend the core API with implementation-specific behavior."
                                             type: string
                                         required:
-                                        - requestHeader
-                                        - requestMirror
                                         - type
                                         type: object
                                       type: array

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1768,6 +1768,7 @@ HTTPRequestHeaderFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 <tr>
@@ -1780,6 +1781,7 @@ HTTPRequestMirrorFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2093,6 +2093,7 @@ HTTPRequestHeaderFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 <tr>
@@ -2105,6 +2106,7 @@ HTTPRequestMirrorFilter
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
I am not really sure if unionDiscriminator even works, but per
https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190325-unions.md#go-tags
the individual items should be optional. Otherwise, you need to specify
all of them which is not quite right.