### PR TITLE
GatewayClass: Add omitempty to provisionedGateways

### DIFF
--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -126,7 +126,7 @@ type GatewayClassStatus struct {
 	// using this class. Implementations must add any Gateways of this class to
 	// this list once they have been provisioned and remove Gateways as soon as
 	// they are deleted or deprovisioned.
-	ProvisionedGateways []GatewayReference `json:"provisionedGateways"`
+	ProvisionedGateways []GatewayReference `json:"provisionedGateways,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -163,8 +163,6 @@ spec:
                   - namespace
                   type: object
                 type: array
-            required:
-            - provisionedGateways
             type: object
         type: object
     served: true


### PR DESCRIPTION
Fix the `gatewayclasses` CRD by annotating the CR's `status.provisionedGateways` field's json tag with the `omitempty` option.

Before this commit, attempting to apply the CRD produced the following error message:

    The CustomResourceDefinition "gatewayclasses.networking.x-k8s.io" is invalid: spec.validation.openAPIV3Schema.properties[status].default.provisionedGateways: Required value

* `apis/v1alpha1/gatewayclass_types.go` (`GatewayClassStatus`): Add `omitempty` to `ProvisionedGateways`.
* `config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml`: Regenerate.