### PR TITLE
Specify printer columns for gateway, gatewayclass, httproute #354

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Class",type=string,JSONPath=`.spec.gatewayClassName`
 
 // Gateway represents an instantiation of a service-traffic handling
 // infrastructure by binding Listeners to a set of IP addresses.

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -24,6 +24,7 @@ import (
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Controller",type=string,JSONPath=`.spec.controller`
 // +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Hostnames",type=string,JSONPath=`.spec.hostnames`
 
 // HTTPRoute is the Schema for the HTTPRoute resource.
 type HTTPRoute struct {

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -16,7 +16,11 @@ spec:
     singular: gatewayclass
   scope: Cluster
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.controller
+      name: Controller
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: "GatewayClass describes a class of Gateways available to the user for creating Gateway resources. \n GatewayClass is a Cluster level resource. \n Support: Core."

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -16,7 +16,11 @@ spec:
     singular: gateway
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.gatewayClassName
+      name: Class
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Gateway represents an instantiation of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -16,7 +16,11 @@ spec:
     singular: httproute
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.hostnames
+      name: Hostnames
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: HTTPRoute is the Schema for the HTTPRoute resource.


### PR DESCRIPTION
Addresses #354. This adds additional columns to print with kubectl get requests using kubebuilder annotations.

```
$ kubectl get gateway
NAME                      CLASS
default-match-gw          default-match-example
gateway                   default-class
my-gateway                acme-lb
my-trafficsplit-gateway   trafficsplit-lb
```

```
$ kubectl get gatewayclass
NAME                    CONTROLLER
acme-lb                 acme.io/gateway-controller
default-match-example   acme.io/gateway-controller
trafficsplit-lb         acme.io/gateway-controller
```

```
$ kubectl get httproute
NAME                  HOSTNAMES
default-match-route   ["default-match.com"]
http-app-1            ["baz.example.com"]
http-trafficsplit-1   ["my.trafficsplit.com"]
```