### PR TITLE
Consistently apply list-map typing to Conditions slices.

### DIFF
--- a/apis/v1alpha1/backendpolicy_types.go
+++ b/apis/v1alpha1/backendpolicy_types.go
@@ -167,7 +167,9 @@ type BackendTLSConfig struct {
 // Route(s) using backends configured by this BackendPolicy.
 type BackendPolicyStatus struct {
 	// Conditions describe the current conditions of the BackendPolicy.
-	// +optional
+	//
+	// +listType=map
+	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -591,12 +591,10 @@ type GatewayStatus struct {
 	// * "Scheduled"
 	// * "Ready"
 	//
-	// +patchMergeKey=type
-	// +patchStrategy=merge
 	// +listType=map
 	// +listMapKey=type
-	// +kubebuilder:default={{type: "Scheduled", status: "False", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	// +kubebuilder:validation:MaxItems=8
+	// +kubebuilder:default={{type: "Scheduled", status: "False", reason:"NotReconciled", message:"Waiting for controller", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// Listeners provide status for each unique listener port defined in the Spec.
@@ -708,6 +706,8 @@ type ListenerStatus struct {
 
 	// Conditions describe the current condition of this listener.
 	//
+	// +listType=map
+	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	Conditions []metav1.Condition `json:"conditions"`
 }

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -121,6 +121,8 @@ type GatewayClassStatus struct {
 	// Conditions is the current status from the controller for
 	// this GatewayClass.
 	//
+	// +listType=map
+	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	// +kubebuilder:default={{type: "InvalidParameters", status: "Unknown", message: "Waiting for controller", reason: "Waiting", lastTransitionTime: "1970-01-01T00:00:00Z"}}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`

--- a/apis/v1alpha1/route_types.go
+++ b/apis/v1alpha1/route_types.go
@@ -143,6 +143,9 @@ type RouteGatewayStatus struct {
 	// route has been admitted or rejected by the Gateway, and why.  Note
 	// that the route's availability is also subject to the Gateway's own
 	// status conditions and listener status.
+	//
+	// +listType=map
+	// +listMapKey=type
 	// +kubebuilder:validation:MaxItems=8
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }

--- a/config/crd/bases/networking.x-k8s.io_backendpolicies.yaml
+++ b/config/crd/bases/networking.x-k8s.io_backendpolicies.yaml
@@ -164,6 +164,9 @@ spec:
                   type: object
                 maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
             type: object
         type: object
     served: true

--- a/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gatewayclasses.yaml
@@ -157,6 +157,9 @@ spec:
                   type: object
                 maxItems: 8
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               provisionedGateways:
                 description: ProvisionedGateways is a list of Gateways that have been provisioned using this class. Implementations must add any Gateways of this class to this list once they have been provisioned and remove Gateways as soon as they are deleted or deprovisioned.
                 items:

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -386,6 +386,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     port:
                       description: Port is the unique Listener port value for which this message is reporting the status. If more than one Gateway Listener shares the same port value, this message reports the combined status of all such Listeners.
                       format: int32

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -503,6 +503,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     gatewayRef:
                       description: GatewayRef is a reference to a Gateway object that is associated with the route.
                       properties:

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -208,6 +208,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     gatewayRef:
                       description: GatewayRef is a reference to a Gateway object that is associated with the route.
                       properties:

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -217,6 +217,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     gatewayRef:
                       description: GatewayRef is a reference to a Gateway object that is associated with the route.
                       properties:

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -208,6 +208,9 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                      x-kubernetes-list-map-keys:
+                      - type
+                      x-kubernetes-list-type: map
                     gatewayRef:
                       description: GatewayRef is a reference to a Gateway object that is associated with the route.
                       properties:

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1017,7 +1017,6 @@ Route(s) using backends configured by this BackendPolicy.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Conditions describe the current conditions of the BackendPolicy.</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1342,7 +1342,6 @@ Route(s) using backends configured by this BackendPolicy.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
 <p>Conditions describe the current conditions of the BackendPolicy.</p>
 </td>
 </tr>


### PR DESCRIPTION
Patch merge strategy is not supported for CRDs, so we can drop those
markers. Apply the list-map markers to all Condition slices. Conditions
should never be optional, since a controller should ensure that all
Condition types are always present in the status field.

This fixes #342 

/cc @robscott @bowei @danehans 