### PR TITLE
Decreasing min weight from 1 to 0

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -557,12 +557,13 @@ type HTTPRouteForwardTo struct {
 	// weight/(sum of all weights in this ForwardTo list). Weight is not a
 	// percentage and the sum of weights does not need to equal 100. If only one
 	// backend is specified, 100% of the traffic is forwarded to that backend.
+	// If weight is set to 0, no traffic should be forwarded for this entry.
 	// If unspecified, weight defaults to 1.
 	//
 	// Support: Core
 	//
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=10000
 	Weight int32 `json:"weight,omitempty"`
 

--- a/apis/v1alpha1/route_types.go
+++ b/apis/v1alpha1/route_types.go
@@ -128,12 +128,13 @@ type RouteForwardTo struct {
 	// weight/(sum of all weights in this ForwardTo list). Weight is not a
 	// percentage and the sum of weights does not need to equal 100. If only one
 	// backend is specified, 100% of the traffic is forwarded to that backend.
+	// If weight is set to 0, no traffic should be forwarded for this entry.
 	// If unspecified, weight defaults to 1.
 	//
 	// Support: Extended
 	//
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	// +kubebuilder:validation:Maximum=10000
 	Weight int32 `json:"weight,omitempty"`
 }

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -310,10 +310,10 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If unspecified, weight defaults to 1. \n Support: Core"
+                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Core"
                             format: int32
                             maximum: 10000
-                            minimum: 1
+                            minimum: 0
                             type: integer
                         type: object
                       maxItems: 4

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -111,10 +111,10 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
                             maximum: 10000
-                            minimum: 1
+                            minimum: 0
                             type: integer
                         type: object
                       maxItems: 4

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -111,10 +111,10 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
                             maximum: 10000
-                            minimum: 1
+                            minimum: 0
                             type: integer
                         type: object
                       maxItems: 4

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -111,10 +111,10 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
                             maximum: 10000
-                            minimum: 1
+                            minimum: 0
                             type: integer
                         type: object
                       maxItems: 4

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -2122,6 +2122,7 @@ referenced by the ServiceName or BackendRef field. computed as
 weight/(sum of all weights in this ForwardTo list). Weight is not a
 percentage and the sum of weights does not need to equal 100. If only one
 backend is specified, 100% of the traffic is forwarded to that backend.
+If weight is set to 0, no traffic should be forwarded for this entry.
 If unspecified, weight defaults to 1.</p>
 <p>Support: Core</p>
 </td>
@@ -3074,6 +3075,7 @@ referenced by the ServiceName or BackendRef field. computed as
 weight/(sum of all weights in this ForwardTo list). Weight is not a
 percentage and the sum of weights does not need to equal 100. If only one
 backend is specified, 100% of the traffic is forwarded to that backend.
+If weight is set to 0, no traffic should be forwarded for this entry.
 If unspecified, weight defaults to 1.</p>
 <p>Support: Extended</p>
 </td>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2435,6 +2435,7 @@ referenced by the ServiceName or BackendRef field. computed as
 weight/(sum of all weights in this ForwardTo list). Weight is not a
 percentage and the sum of weights does not need to equal 100. If only one
 backend is specified, 100% of the traffic is forwarded to that backend.
+If weight is set to 0, no traffic should be forwarded for this entry.
 If unspecified, weight defaults to 1.</p>
 <p>Support: Core</p>
 </td>
@@ -3387,6 +3388,7 @@ referenced by the ServiceName or BackendRef field. computed as
 weight/(sum of all weights in this ForwardTo list). Weight is not a
 percentage and the sum of weights does not need to equal 100. If only one
 backend is specified, 100% of the traffic is forwarded to that backend.
+If weight is set to 0, no traffic should be forwarded for this entry.
 If unspecified, weight defaults to 1.</p>
 <p>Support: Extended</p>
 </td>


### PR DESCRIPTION
This was suggested by @mark-church as a way to simplify blue green deployments or rollbacks. Users may want to start/end with a weight of 0 to simplify the workflow. 

/cc @danehans @hbagdi @jpeach 