### PR TITLE
Clean up match type and add regex header match

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -218,9 +218,10 @@ const (
 // Valid HeaderMatchType values are:
 //
 // * "Exact"
+// * "RegularExpression"
 // * "ImplementationSpecific"
 //
-// +kubebuilder:validation:Enum=Exact;ImplementationSpecific
+// +kubebuilder:validation:Enum=Exact;RegularExpression;ImplementationSpecific
 type HeaderMatchType string
 
 // HeaderMatchType constants.
@@ -229,6 +230,7 @@ const (
 	// Field name matches are case-insensitive while field value matches
 	// are case-sensitive.
 	HeaderMatchExact                  HeaderMatchType = "Exact"
+	HeaderMatchRegularExpression      HeaderMatchType = "RegularExpression"
 	HeaderMatchImplementationSpecific HeaderMatchType = "ImplementationSpecific"
 )
 
@@ -244,8 +246,6 @@ type HTTPPathMatch struct {
 	// Please read the implementation's documentation to determine the supported
 	// dialect.
 	//
-	// Default: "Prefix"
-	//
 	// +kubebuilder:default=Prefix
 	Type PathMatchType `json:"type,omitempty"`
 
@@ -257,13 +257,15 @@ type HTTPPathMatch struct {
 
 // HTTPHeaderMatch describes how to select a HTTP route by matching HTTP request headers.
 type HTTPHeaderMatch struct {
-	// HeaderMatchType specifies how to match a HTTP request
-	// header against the Values map.
+	// Type specifies how to match against the value of the header.
 	//
 	// Support: core (Exact)
-	// Support: custom (ImplementationSpecific)
+	// Support: custom (RegularExpression, ImplementationSpecific)
 	//
-	// Default: "Exact"
+	// Since RegularExpression PathType has custom conformance, implementations
+	// can support POSIX, PCRE or any other dialects of regular expressions.
+	// Please read the implementation's documentation to determine the supported
+	// dialect.
 	//
 	// +kubebuilder:default=Exact
 	Type HeaderMatchType `json:"type,omitempty"`

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -355,9 +355,10 @@ spec:
                             properties:
                               type:
                                 default: Exact
-                                description: "HeaderMatchType specifies how to match a HTTP request header against the Values map. \n Support: core (Exact) Support: custom (ImplementationSpecific) \n Default: \"Exact\""
+                                description: "Type specifies how to match against the value of the header. \n Support: core (Exact) Support: custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression PathType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
                                 enum:
                                 - Exact
+                                - RegularExpression
                                 - ImplementationSpecific
                                 type: string
                               values:
@@ -376,7 +377,7 @@ spec:
                             properties:
                               type:
                                 default: Prefix
-                                description: "Type specifies how to match against the path Value. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression PathType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect. \n Default: \"Prefix\""
+                                description: "Type specifies how to match against the path Value. \n Support: core (Exact, Prefix) Support: custom (RegularExpression, ImplementationSpecific) \n Since RegularExpression PathType has custom conformance, implementations can support POSIX, PCRE or any other dialects of regular expressions. Please read the implementation's documentation to determine the supported dialect."
                                 enum:
                                 - Exact
                                 - Prefix

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1697,11 +1697,13 @@ HeaderMatchType
 </em>
 </td>
 <td>
-<p>HeaderMatchType specifies how to match a HTTP request
-header against the Values map.</p>
+<p>Type specifies how to match against the value of the header.</p>
 <p>Support: core (Exact)
-Support: custom (ImplementationSpecific)</p>
-<p>Default: &ldquo;Exact&rdquo;</p>
+Support: custom (RegularExpression, ImplementationSpecific)</p>
+<p>Since RegularExpression PathType has custom conformance, implementations
+can support POSIX, PCRE or any other dialects of regular expressions.
+Please read the implementation&rsquo;s documentation to determine the supported
+dialect.</p>
 </td>
 </tr>
 <tr>
@@ -1757,7 +1759,6 @@ Support: custom (RegularExpression, ImplementationSpecific)</p>
 can support POSIX, PCRE or any other dialects of regular expressions.
 Please read the implementation&rsquo;s documentation to determine the supported
 dialect.</p>
-<p>Default: &ldquo;Prefix&rdquo;</p>
 </td>
 </tr>
 <tr>
@@ -2490,6 +2491,7 @@ RouteStatus
 Valid HeaderMatchType values are:</p>
 <ul>
 <li>&ldquo;Exact&rdquo;</li>
+<li>&ldquo;RegularExpression&rdquo;</li>
 <li>&ldquo;ImplementationSpecific&rdquo;</li>
 </ul>
 </p>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2010,11 +2010,13 @@ HeaderMatchType
 </em>
 </td>
 <td>
-<p>HeaderMatchType specifies how to match a HTTP request
-header against the Values map.</p>
+<p>Type specifies how to match against the value of the header.</p>
 <p>Support: core (Exact)
-Support: custom (ImplementationSpecific)</p>
-<p>Default: &ldquo;Exact&rdquo;</p>
+Support: custom (RegularExpression, ImplementationSpecific)</p>
+<p>Since RegularExpression PathType has custom conformance, implementations
+can support POSIX, PCRE or any other dialects of regular expressions.
+Please read the implementation&rsquo;s documentation to determine the supported
+dialect.</p>
 </td>
 </tr>
 <tr>
@@ -2070,7 +2072,6 @@ Support: custom (RegularExpression, ImplementationSpecific)</p>
 can support POSIX, PCRE or any other dialects of regular expressions.
 Please read the implementation&rsquo;s documentation to determine the supported
 dialect.</p>
-<p>Default: &ldquo;Prefix&rdquo;</p>
 </td>
 </tr>
 <tr>
@@ -2803,6 +2804,7 @@ RouteStatus
 Valid HeaderMatchType values are:</p>
 <ul>
 <li>&ldquo;Exact&rdquo;</li>
+<li>&ldquo;RegularExpression&rdquo;</li>
 <li>&ldquo;ImplementationSpecific&rdquo;</li>
 </ul>
 </p>


### PR DESCRIPTION
ImplementationSpecific and RegularExpression are kept separate for
end-user documentation purposes. There is some expectation of
portability for some regexes across implementation in future.