### PR TITLE
remove hardcoded resources in delete-crds.sh

### DIFF
--- a/hack/delete-crds.sh
+++ b/hack/delete-crds.sh
@@ -20,11 +20,7 @@ set -o pipefail
 
 # Delete all CR and CRDs installed by service-apis.
 
-RESOURCES="
-  gatewayclasses.networking.x-k8s.io
-  gateways.networking.x-k8s.io
-  httproutes.networking.x-k8s.io
-  tcproutes.networking.x-k8s.io"
+RESOURCES=$(kubectl api-resources --api-group=networking.x-k8s.io -o name)
 
 for TYPE in ${RESOURCES}; do
   kubectl delete ${TYPE} --all


### PR DESCRIPTION
The script goes out of date easily. This patch reduces the maintainence
burden by automating the resource list.