### PR TITLE
clean up community doc to removec outdated links

### DIFF
--- a/docs-src/community.md
+++ b/docs-src/community.md
@@ -44,10 +44,13 @@ on Wednesdays.
 
 ### Meeting notes
 
-[Meeting schedule scratch pad][meeting-sched-scratch]
-[meeting-sched-scratch]: https://docs.google.com/spreadsheets/d/1_jXy5hHLAmLTVN9rTNsI3Xx_Dzc0JvLqNqjS9hdzryI
+Meeting agendas and notes are recorded in the [meeting notes doc][meeting-notes].
 
+All meetings are recorded and automatically uploaded to youtube:
 [Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb).
+
+Some initial recordings of this working group were done manually and can be
+found in the below table:
 
 | Date               |                                |
 |--------------------|--------------------------------|
@@ -70,14 +73,6 @@ on Wednesdays.
 [kubecon-2019-eu-discussion]: https://docs.google.com/document/d/1n8AaDiPXyZHTosm1dscWhzpbcZklP3vd11fA6L6ajlY/preview
 [sig-net-2019-11-sync]: https://docs.google.com/document/d/1AqBaxNX0uS0fb_fSpVL9c8TmaSP7RYkWO8U_SdJH67k/preview
 [meeting-notes]: https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit
-
-## Design docs
-
-| Title | Description |
-|-------|-------------|
-| [API sketch][api-sketch] | Sketch of the proposed API |
-
-[api-sketch]:  https://docs.google.com/document/d/1BxYbDovMwnEqe8lj8JwHo8YxHAt3oC7ezhlFsG_tyag
 
 ## Presentations, Talks
 

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -339,13 +339,6 @@
 </li>
       
         <li class="md-nav__item">
-  <a href="#design-docs" class="md-nav__link">
-    Design docs
-  </a>
-  
-</li>
-      
-        <li class="md-nav__item">
   <a href="#presentations-talks" class="md-nav__link">
     Presentations, Talks
   </a>
@@ -444,13 +437,6 @@
 </li>
       
         <li class="md-nav__item">
-  <a href="#design-docs" class="md-nav__link">
-    Design docs
-  </a>
-  
-</li>
-      
-        <li class="md-nav__item">
   <a href="#presentations-talks" class="md-nav__link">
     Presentations, Talks
   </a>
@@ -511,8 +497,11 @@ on Wednesdays.</p>
 <li>Wednesday 3:00 (15:00) PM Pacific <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&tmeid=N2VlZWhzanNlbjhvcjRsZjdyZ25kZG9tMTYgODhmZTFsM3FmbjJiNnIxMWs4dW01YW03NmNAZw&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a></li>
 </ul>
 <h3 id="meeting-notes">Meeting notes</h3>
-<p><a href="https://docs.google.com/spreadsheets/d/1_jXy5hHLAmLTVN9rTNsI3Xx_Dzc0JvLqNqjS9hdzryI">Meeting schedule scratch pad</a></p>
-<p><a href="https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb">Meeting recordings</a>.</p>
+<p>Meeting agendas and notes are recorded in the <a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes doc</a>.</p>
+<p>All meetings are recorded and automatically uploaded to youtube:
+<a href="https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb">Meeting recordings</a>.</p>
+<p>Some initial recordings of this working group were done manually and can be
+found in the below table:</p>
 <table>
 <thead>
 <tr>
@@ -576,21 +565,6 @@ on Wednesdays.</p>
 <tr>
 <td>May, 2019</td>
 <td><a href="https://docs.google.com/document/d/1n8AaDiPXyZHTosm1dscWhzpbcZklP3vd11fA6L6ajlY/preview">Kubecon 2019 Barcelona: SIG-NETWORK discussion (general topics, includes V2)</a></td>
-</tr>
-</tbody>
-</table>
-<h2 id="design-docs">Design docs</h2>
-<table>
-<thead>
-<tr>
-<th>Title</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><a href="https://docs.google.com/document/d/1BxYbDovMwnEqe8lj8JwHo8YxHAt3oC7ezhlFsG_tyag">API sketch</a></td>
-<td>Sketch of the proposed API</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
- removes the outdated cschedule scratchpad
- removes the old design doc