### PR TITLE
add recommendation to add finalizer to GatewayClass

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -27,6 +27,11 @@ import (
 
 // Gateway represents an instantiation of a service-traffic handling
 // infrastructure by binding Listeners to a set of IP addresses.
+//
+// Implementations should add the `gateway-exists-finalizer.networking.x-k8s.io`
+// finalizer on the associated GatewayClass whenever Gateway(s) is running.
+// This ensures that a GatewayClass associated with a Gateway(s) is not
+// deleted while in use.
 type Gateway struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -114,6 +114,10 @@ const (
 	// validity of the Parameters set for a given controller. This
 	// will initially start off as "Unknown".
 	GatewayClassConditionStatusInvalidParameters GatewayClassConditionType = "InvalidParameters"
+
+	// GatewayClassFinalizerGatewaysExist should be added as a finalizer to the
+	// GatewayClass whenever there are provisioned Gateways using a GatewayClass.
+	GatewayClassFinalizerGatewaysExist = "gateway-exists-finalizer.networking.x-k8s.io"
 )
 
 // GatewayClassStatus is the current status for the GatewayClass.

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -23,7 +23,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: Gateway represents an instantiation of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses.
+        description: "Gateway represents an instantiation of a service-traffic handling infrastructure by binding Listeners to a set of IP addresses. \n Implementations should add the `gateway-exists-finalizer.networking.x-k8s.io` finalizer on the associated GatewayClass whenever Gateway(s) is running. This ensures that a GatewayClass associated with a Gateway(s) is not deleted while in use."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -140,6 +140,10 @@ BackendPolicyStatus
 <p>
 <p>Gateway represents an instantiation of a service-traffic handling
 infrastructure by binding Listeners to a set of IP addresses.</p>
+<p>Implementations should add the <code>gateway-exists-finalizer.networking.x-k8s.io</code>
+finalizer on the associated GatewayClass whenever Gateway(s) is running.
+This ensures that a GatewayClass associated with a Gateway(s) is not
+deleted while in use.</p>
 </p>
 <table>
 <thead>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -453,6 +453,10 @@ BackendPolicyStatus
 <p>
 <p>Gateway represents an instantiation of a service-traffic handling
 infrastructure by binding Listeners to a set of IP addresses.</p>
+<p>Implementations should add the <code>gateway-exists-finalizer.networking.x-k8s.io</code>
+finalizer on the associated GatewayClass whenever Gateway(s) is running.
+This ensures that a GatewayClass associated with a Gateway(s) is not
+deleted while in use.</p>
 </p>
 <table>
 <thead>


### PR DESCRIPTION
There is nothing that prevents a user to delete a GatewayClass resource
when there are Gateway resources that refer to it.

This patch adds in recommendation to use finalizers to prevent deletion
of GatewayClass resources that are in use.

This is a secondary safety-net. The first one is based on our personas
and RBAC where for a large cluster, only a small subset of users should
have delete permissions on GatewayClass.

See #170