### PR TITLE
Fixing verify-golint by using mod=readonly go flag

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,11 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+readonly KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 cd "${KUBE_ROOT}"
 
-GOLINT=${GOLINT:-"golint"}
+readonly GOFLAGS="-mod=readonly"
+readonly GOLINT=${GOLINT:-"golint"}
 
 if ! command -v ${GOLINT} &> /dev/null; then
   echo "golint not found, installing"


### PR DESCRIPTION
This change has been verified to work in https://github.com/kubernetes-sigs/service-apis/pull/416. 

/cc @jpeach @hbagdi 