### PR TITLE
define a new Go type Port for consolidation 

### DIFF
--- a/apis/v1alpha1/backendpolicy_types.go
+++ b/apis/v1alpha1/backendpolicy_types.go
@@ -82,9 +82,7 @@ type BackendRef struct {
 	// Port is the port of the referent. If unspecified, this policy applies to
 	// all ports on the backend.
 	// +optional
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port *int32 `json:"port,omitempty"`
+	Port *PortNumber `json:"port,omitempty"`
 }
 
 // BackendTLSConfig describes TLS configuration for a backend.

--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -144,10 +144,7 @@ type Listener struct {
 	// same port, subject to the Listener compatibility rules.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port int32 `json:"port"`
+	Port PortNumber `json:"port"`
 
 	// Protocol specifies the network protocol this listener
 	// expects to receive. The GatewayClass MUST validate that
@@ -692,10 +689,7 @@ type ListenerStatus struct {
 	// is reporting the status. If more than one Gateway Listener
 	// shares the same port value, this message reports the combined
 	// status of all such Listeners.
-	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port int32 `json:"port"`
+	Port PortNumber `json:"port"`
 
 	// Conditions describe the current condition of this listener.
 	//

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -478,9 +478,7 @@ type HTTPRequestMirrorFilter struct {
 	// Port specifies the destination port number to use for the
 	// backend referenced by the ServiceName or BackendRef field.
 	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port int32 `json:"port"`
+	Port PortNumber `json:"port"`
 }
 
 // HTTPRouteForwardTo defines how a HTTPRoute should forward a request.
@@ -522,9 +520,7 @@ type HTTPRouteForwardTo struct {
 	//
 	// Support: Core
 	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port int32 `json:"port"`
+	Port PortNumber `json:"port"`
 
 	// Weight specifies the proportion of traffic forwarded to the backend
 	// referenced by the ServiceName or BackendRef field. computed as

--- a/apis/v1alpha1/route_types.go
+++ b/apis/v1alpha1/route_types.go
@@ -55,6 +55,12 @@ type RouteGateways struct {
 	GatewayRefs []GatewayReference `json:"gatewayRefs,omitempty"`
 }
 
+// PortNumber defines a network port.
+//
+// +kubebuilder:validation:Minimum=1
+// +kubebuilder:validation:Maximum=65535
+type PortNumber int32
+
 // GatewayReference identifies a Gateway in a specified namespace.
 type GatewayReference struct {
 	// Name is the name of the referent.
@@ -106,10 +112,7 @@ type RouteForwardTo struct {
 	// backend referenced by the ServiceName or BackendRef field.
 	//
 	// Support: Core
-	//
-	// +kubebuilder:validation:Minimum=1
-	// +kubebuilder:validation:Maximum=65535
-	Port int32 `json:"port"`
+	Port PortNumber `json:"port"`
 
 	// Weight specifies the proportion of traffic forwarded to the backend
 	// referenced by the ServiceName or BackendRef field. computed as

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -138,7 +138,7 @@ func (in *BackendRef) DeepCopyInto(out *BackendRef) {
 	*out = *in
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
-		*out = new(int32)
+		*out = new(PortNumber)
 		**out = **in
 	}
 }

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1036,7 +1036,9 @@ string
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -1817,7 +1819,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -1992,7 +1996,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2505,7 +2511,9 @@ be compatible with the specified Protocol field.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2646,7 +2654,9 @@ field.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2749,6 +2759,20 @@ Valid PathMatchType values are:</p>
 <li>&ldquo;RegularExpression&rdquo;</li>
 <li>&ldquo;ImplementationSpecific&rdquo;</li>
 </ul>
+</p>
+<h3 id="networking.x-k8s.io/v1alpha1.PortNumber">PortNumber
+(<code>int32</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#networking.x-k8s.io/v1alpha1.BackendRef">BackendRef</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRequestMirrorFilter">HTTPRequestMirrorFilter</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">HTTPRouteForwardTo</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.ListenerStatus">ListenerStatus</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.RouteForwardTo">RouteForwardTo</a>)
+</p>
+<p>
+<p>PortNumber defines a network port.</p>
 </p>
 <h3 id="networking.x-k8s.io/v1alpha1.ProtocolType">ProtocolType
 (<code>string</code> alias)</p></h3>
@@ -2935,7 +2959,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1471,7 +1471,9 @@ string
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2252,7 +2254,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2427,7 +2431,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -2940,7 +2946,9 @@ be compatible with the specified Protocol field.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -3081,7 +3089,9 @@ field.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>
@@ -3184,6 +3194,20 @@ Valid PathMatchType values are:</p>
 <li>&ldquo;RegularExpression&rdquo;</li>
 <li>&ldquo;ImplementationSpecific&rdquo;</li>
 </ul>
+</p>
+<h3 id="networking.x-k8s.io/v1alpha1.PortNumber">PortNumber
+(<code>int32</code> alias)</p></h3>
+<p>
+(<em>Appears on:</em>
+<a href="#networking.x-k8s.io/v1alpha1.BackendRef">BackendRef</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRequestMirrorFilter">HTTPRequestMirrorFilter</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.HTTPRouteForwardTo">HTTPRouteForwardTo</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.ListenerStatus">ListenerStatus</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.RouteForwardTo">RouteForwardTo</a>)
+</p>
+<p>
+<p>PortNumber defines a network port.</p>
 </p>
 <h3 id="networking.x-k8s.io/v1alpha1.ProtocolType">ProtocolType
 (<code>string</code> alias)</p></h3>
@@ -3370,7 +3394,9 @@ condition that describes the error more specifically.</p>
 <td>
 <code>port</code></br>
 <em>
-int32
+<a href="#networking.x-k8s.io/v1alpha1.PortNumber">
+PortNumber
+</a>
 </em>
 </td>
 <td>


### PR DESCRIPTION
- Defines a new type Port
- Re-use the type across all instances of port
- Change the type from int32 to uint32


### Note

I spotted this while working on #422.
Please review only the last commit here. To avoid conflicts, this PR builds on top of #422 and should be merged after that lands in.