### PR TITLE
Cleanup from prealpha feedback

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -408,7 +408,7 @@ type RouteBindingSelector struct {
 	//
 	// routes:
 	//   group: acme.io
-	//   resource: fooroutes
+	//   kind: FooRoute
 	//
 	// Support: Core
 	//

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -168,14 +168,14 @@ type HTTPRouteRule struct {
 	// Filters define the filters that are applied to requests that match
 	// this rule.
 	//
-	// The effects of ordering of multiple behaviors are currently undefined.
+	// The effects of ordering of multiple behaviors are currently unspecified.
 	// This can change in the future based on feedback during the alpha stage.
 	//
 	// Conformance-levels at this level are defined based on the type of filter:
 	// - ALL core filters MUST be supported by all implementations.
 	// - Implementers are encouraged to support extended filters.
 	// - Implementation-specific custom filters have no API guarantees across implementations.
-	// Specifying a core filter multiple times has undefined or custom conformance.
+	// Specifying a core filter multiple times has unspecified or custom conformance.
 	//
 	// Support: core
 	//
@@ -386,20 +386,23 @@ const (
 	// HTTPRouteFilterRequestHeaderModifier can be used to add or remove an HTTP
 	// header from an HTTP request before it is sent to the upstream target.
 	//
-	// Support: Core
+	// Support in HTTPRouteRule: Core
+	// Support in HTTPRouteForwardTo: Extended
 	HTTPRouteFilterRequestHeaderModifier HTTPRouteFilterType = "RequestHeaderModifier"
 
 	// HTTPRouteFilterRequestMirror can be used to mirror HTTP requests to a
 	// different backend. The responses from this backend MUST be ignored by
 	// the Gateway.
 	//
-	// Support: Extended
+	// Support in HTTPRouteRule: Extended
+	// Support in HTTPRouteForwardTo: Extended
 	HTTPRouteFilterRequestMirror HTTPRouteFilterType = "RequestMirror"
 
 	// HTTPRouteFilterExtensionRef should be used for configuring custom
 	// HTTP filters.
 	//
-	// Support: Implementation-specific
+	// Support in HTTPRouteRule: Custom
+	// Support in HTTPRouteForwardTo: Custom
 	HTTPRouteFilterExtensionRef HTTPRouteFilterType = "ExtensionRef"
 )
 
@@ -528,29 +531,30 @@ type HTTPRouteForwardTo struct {
 	//
 	Port PortNumber `json:"port"`
 
-	// Weight specifies the proportion of traffic forwarded to the backend
-	// referenced by the ServiceName or BackendRef field. computed as
-	// weight/(sum of all weights in this ForwardTo list). Weight is not a
-	// percentage and the sum of weights does not need to equal 100. If only one
-	// backend is specified, 100% of the traffic is forwarded to that backend.
-	// If weight is set to 0, no traffic should be forwarded for this entry.
-	// If unspecified, weight defaults to 1.
+	// Weight specifies the proportion of HTTP requests forwarded to the backend
+	// referenced by the ServiceName or BackendRef field. This is computed as
+	// weight/(sum of all weights in this ForwardTo list). For non-zero values,
+	// there may be some epsilon from the exact proportion defined here
+	// depending on the precision an implementation supports. Weight is not a
+	// percentage and the sum of weights does not need to equal 100.
+	//
+	// If only one backend is specified and it has a weight greater than 0, 100%
+	// of the traffic is forwarded to that backend. If weight is set to 0, no
+	// traffic should be forwarded for this entry. If unspecified, weight
+	// defaults to 1.
 	//
 	// Support: Core
 	//
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=10000
+	// +kubebuilder:validation:Maximum=1000000
 	Weight int32 `json:"weight,omitempty"`
 
 	// Filters defined at this-level should be executed if and only if the
 	// request is being forwarded to the backend defined here.
 	//
-	// Conformance: Filtering support, including core filters, is NOT guaranteed
-	// at this-level. Use Filters in HTTPRouteRule for portable filters across
-	// implementations.
-	//
-	// Support: Custom
+	// Support: Custom (For broader support of filters, use the Filters field
+	// in HTTPRouteRule.)
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=16

--- a/apis/v1alpha1/route_types.go
+++ b/apis/v1alpha1/route_types.go
@@ -114,19 +114,23 @@ type RouteForwardTo struct {
 	// Support: Core
 	Port PortNumber `json:"port"`
 
-	// Weight specifies the proportion of traffic forwarded to the backend
-	// referenced by the ServiceName or BackendRef field. computed as
-	// weight/(sum of all weights in this ForwardTo list). Weight is not a
-	// percentage and the sum of weights does not need to equal 100. If only one
-	// backend is specified, 100% of the traffic is forwarded to that backend.
-	// If weight is set to 0, no traffic should be forwarded for this entry.
-	// If unspecified, weight defaults to 1.
+	// Weight specifies the proportion of HTTP requests forwarded to the backend
+	// referenced by the ServiceName or BackendRef field. This is computed as
+	// weight/(sum of all weights in this ForwardTo list). For non-zero values,
+	// there may be some epsilon from the exact proportion defined here
+	// depending on the precision an implementation supports. Weight is not a
+	// percentage and the sum of weights does not need to equal 100.
+	//
+	// If only one backend is specified and it has a weight greater than 0, 100%
+	// of the traffic is forwarded to that backend. If weight is set to 0, no
+	// traffic should be forwarded for this entry. If unspecified, weight
+	// defaults to 1.
 	//
 	// Support: Extended
 	//
 	// +kubebuilder:default=1
 	// +kubebuilder:validation:Minimum=0
-	// +kubebuilder:validation:Maximum=10000
+	// +kubebuilder:validation:Maximum=1000000
 	Weight int32 `json:"weight,omitempty"`
 }
 
@@ -166,5 +170,11 @@ type RouteStatus struct {
 	// manages the Gateway should add an entry to this list when the
 	// controller first sees the route and should update the entry as
 	// appropriate when the route is modified.
+	//
+	// A maximum of 100 Gateways will be represented in this list. If this list
+	// is full, there may be additional Gateways using this Route that are not
+	// included in the list.
+	//
+	// +kubebuilder:validation:MaxItems=100
 	Gateways []RouteGatewayStatus `json:"gateways"`
 }

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -87,7 +87,7 @@ spec:
                       properties:
                         group:
                           default: networking.x-k8s.io
-                          description: "Group is the group of the route resource to select. Omitting the value or specifying the empty string indicates the networking.x-k8s.io API group. For example, use the following to select an HTTPRoute: \n routes:   kind: HTTPRoute \n Otherwise, if an alternative API group is desired, specify the desired group: \n routes:   group: acme.io   resource: fooroutes \n Support: Core"
+                          description: "Group is the group of the route resource to select. Omitting the value or specifying the empty string indicates the networking.x-k8s.io API group. For example, use the following to select an HTTPRoute: \n routes:   kind: HTTPRoute \n Otherwise, if an alternative API group is desired, specify the desired group: \n routes:   group: acme.io   kind: FooRoute \n Support: Core"
                           maxLength: 253
                           minLength: 1
                           type: string

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -85,7 +85,7 @@ spec:
                   description: HTTPRouteRule defines semantics for matching an incoming HTTP request against a set of matching rules and executing an action (and optionally filters) on the request.
                   properties:
                     filters:
-                      description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently undefined. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across implementations. Specifying a core filter multiple times has undefined or custom conformance. \n Support: core"
+                      description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently unspecified. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across implementations. Specifying a core filter multiple times has unspecified or custom conformance. \n Support: core"
                       items:
                         description: 'HTTPRouteFilter defines additional processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express additional processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter. TODO(hbagdi): re-render CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298 - https://github.com/kubernetes-sigs/controller-tools/issues/461'
                         properties:
@@ -207,7 +207,7 @@ spec:
                             - name
                             type: object
                           filters:
-                            description: "Filters defined at this-level should be executed if and only if the request is being forwarded to the backend defined here. \n Conformance: Filtering support, including core filters, is NOT guaranteed at this-level. Use Filters in HTTPRouteRule for portable filters across implementations. \n Support: Custom"
+                            description: "Filters defined at this-level should be executed if and only if the request is being forwarded to the backend defined here. \n Support: Custom (For broader support of filters, use the Filters field in HTTPRouteRule.)"
                             items:
                               description: 'HTTPRouteFilter defines additional processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express additional processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter. TODO(hbagdi): re-render CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298 - https://github.com/kubernetes-sigs/controller-tools/issues/461'
                               properties:
@@ -312,9 +312,9 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Core"
+                            description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Core"
                             format: int32
-                            maximum: 10000
+                            maximum: 1000000
                             minimum: 0
                             type: integer
                         required:
@@ -438,7 +438,7 @@ spec:
             description: HTTPRouteStatus defines the observed state of HTTPRoute.
             properties:
               gateways:
-                description: Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified.
+                description: "Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list."
                 items:
                   description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
                   properties:
@@ -510,6 +510,7 @@ spec:
                   required:
                   - gatewayRef
                   type: object
+                maxItems: 100
                 type: array
             required:
             - gateways

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -111,9 +111,9 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
-                            maximum: 10000
+                            maximum: 1000000
                             minimum: 0
                             type: integer
                         required:
@@ -161,7 +161,7 @@ spec:
             description: TCPRouteStatus defines the observed state of TCPRoute
             properties:
               gateways:
-                description: Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified.
+                description: "Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list."
                 items:
                   description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
                   properties:
@@ -233,6 +233,7 @@ spec:
                   required:
                   - gatewayRef
                   type: object
+                maxItems: 100
                 type: array
             required:
             - gateways

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -111,9 +111,9 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
-                            maximum: 10000
+                            maximum: 1000000
                             minimum: 0
                             type: integer
                         required:
@@ -170,7 +170,7 @@ spec:
             description: TLSRouteStatus defines the observed state of TLSRoute
             properties:
               gateways:
-                description: Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified.
+                description: "Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list."
                 items:
                   description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
                   properties:
@@ -242,6 +242,7 @@ spec:
                   required:
                   - gatewayRef
                   type: object
+                maxItems: 100
                 type: array
             required:
             - gateways

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -111,9 +111,9 @@ spec:
                             type: string
                           weight:
                             default: 1
-                            description: "Weight specifies the proportion of traffic forwarded to the backend referenced by the ServiceName or BackendRef field. computed as weight/(sum of all weights in this ForwardTo list). Weight is not a percentage and the sum of weights does not need to equal 100. If only one backend is specified, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
+                            description: "Weight specifies the proportion of HTTP requests forwarded to the backend referenced by the ServiceName or BackendRef field. This is computed as weight/(sum of all weights in this ForwardTo list). For non-zero values, there may be some epsilon from the exact proportion defined here depending on the precision an implementation supports. Weight is not a percentage and the sum of weights does not need to equal 100. \n If only one backend is specified and it has a weight greater than 0, 100% of the traffic is forwarded to that backend. If weight is set to 0, no traffic should be forwarded for this entry. If unspecified, weight defaults to 1. \n Support: Extended"
                             format: int32
-                            maximum: 10000
+                            maximum: 1000000
                             minimum: 0
                             type: integer
                         required:
@@ -161,7 +161,7 @@ spec:
             description: UDPRouteStatus defines the observed state of UDPRoute.
             properties:
               gateways:
-                description: Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified.
+                description: "Gateways is a list of the Gateways that are associated with the route, and the status of the route with respect to each of these Gateways. When a Gateway selects this route, the controller that manages the Gateway should add an entry to this list when the controller first sees the route and should update the entry as appropriate when the route is modified. \n A maximum of 100 Gateways will be represented in this list. If this list is full, there may be additional Gateways using this Route that are not included in the list."
                 items:
                   description: RouteGatewayStatus describes the status of a route with respect to an associated Gateway.
                   properties:
@@ -233,6 +233,7 @@ spec:
                   required:
                   - gatewayRef
                   type: object
+                maxItems: 100
                 type: array
             required:
             - gateways

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -2044,13 +2044,16 @@ int32
 </em>
 </td>
 <td>
-<p>Weight specifies the proportion of traffic forwarded to the backend
-referenced by the ServiceName or BackendRef field. computed as
-weight/(sum of all weights in this ForwardTo list). Weight is not a
-percentage and the sum of weights does not need to equal 100. If only one
-backend is specified, 100% of the traffic is forwarded to that backend.
-If weight is set to 0, no traffic should be forwarded for this entry.
-If unspecified, weight defaults to 1.</p>
+<p>Weight specifies the proportion of HTTP requests forwarded to the backend
+referenced by the ServiceName or BackendRef field. This is computed as
+weight/(sum of all weights in this ForwardTo list). For non-zero values,
+there may be some epsilon from the exact proportion defined here
+depending on the precision an implementation supports. Weight is not a
+percentage and the sum of weights does not need to equal 100.</p>
+<p>If only one backend is specified and it has a weight greater than 0, 100%
+of the traffic is forwarded to that backend. If weight is set to 0, no
+traffic should be forwarded for this entry. If unspecified, weight
+defaults to 1.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2067,10 +2070,8 @@ If unspecified, weight defaults to 1.</p>
 <em>(Optional)</em>
 <p>Filters defined at this-level should be executed if and only if the
 request is being forwarded to the backend defined here.</p>
-<p>Conformance: Filtering support, including core filters, is NOT guaranteed
-at this-level. Use Filters in HTTPRouteRule for portable filters across
-implementations.</p>
-<p>Support: Custom</p>
+<p>Support: Custom (For broader support of filters, use the Filters field
+in HTTPRouteRule.)</p>
 </td>
 </tr>
 </tbody>
@@ -2223,13 +2224,13 @@ HTTP request.</p>
 <em>(Optional)</em>
 <p>Filters define the filters that are applied to requests that match
 this rule.</p>
-<p>The effects of ordering of multiple behaviors are currently undefined.
+<p>The effects of ordering of multiple behaviors are currently unspecified.
 This can change in the future based on feedback during the alpha stage.</p>
 <p>Conformance-levels at this level are defined based on the type of filter:
 - ALL core filters MUST be supported by all implementations.
 - Implementers are encouraged to support extended filters.
 - Implementation-specific custom filters have no API guarantees across implementations.
-Specifying a core filter multiple times has undefined or custom conformance.</p>
+Specifying a core filter multiple times has unspecified or custom conformance.</p>
 <p>Support: core</p>
 </td>
 </tr>
@@ -2826,7 +2827,7 @@ kind: HTTPRoute</p>
 group:</p>
 <p>routes:
 group: acme.io
-resource: fooroutes</p>
+kind: FooRoute</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2939,13 +2940,16 @@ int32
 </em>
 </td>
 <td>
-<p>Weight specifies the proportion of traffic forwarded to the backend
-referenced by the ServiceName or BackendRef field. computed as
-weight/(sum of all weights in this ForwardTo list). Weight is not a
-percentage and the sum of weights does not need to equal 100. If only one
-backend is specified, 100% of the traffic is forwarded to that backend.
-If weight is set to 0, no traffic should be forwarded for this entry.
-If unspecified, weight defaults to 1.</p>
+<p>Weight specifies the proportion of HTTP requests forwarded to the backend
+referenced by the ServiceName or BackendRef field. This is computed as
+weight/(sum of all weights in this ForwardTo list). For non-zero values,
+there may be some epsilon from the exact proportion defined here
+depending on the precision an implementation supports. Weight is not a
+percentage and the sum of weights does not need to equal 100.</p>
+<p>If only one backend is specified and it has a weight greater than 0, 100%
+of the traffic is forwarded to that backend. If weight is set to 0, no
+traffic should be forwarded for this entry. If unspecified, weight
+defaults to 1.</p>
 <p>Support: Extended</p>
 </td>
 </tr>
@@ -3161,6 +3165,9 @@ Gateways. When a Gateway selects this route, the controller that
 manages the Gateway should add an entry to this list when the
 controller first sees the route and should update the entry as
 appropriate when the route is modified.</p>
+<p>A maximum of 100 Gateways will be represented in this list. If this list
+is full, there may be additional Gateways using this Route that are not
+included in the list.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2467,13 +2467,16 @@ int32
 </em>
 </td>
 <td>
-<p>Weight specifies the proportion of traffic forwarded to the backend
-referenced by the ServiceName or BackendRef field. computed as
-weight/(sum of all weights in this ForwardTo list). Weight is not a
-percentage and the sum of weights does not need to equal 100. If only one
-backend is specified, 100% of the traffic is forwarded to that backend.
-If weight is set to 0, no traffic should be forwarded for this entry.
-If unspecified, weight defaults to 1.</p>
+<p>Weight specifies the proportion of HTTP requests forwarded to the backend
+referenced by the ServiceName or BackendRef field. This is computed as
+weight/(sum of all weights in this ForwardTo list). For non-zero values,
+there may be some epsilon from the exact proportion defined here
+depending on the precision an implementation supports. Weight is not a
+percentage and the sum of weights does not need to equal 100.</p>
+<p>If only one backend is specified and it has a weight greater than 0, 100%
+of the traffic is forwarded to that backend. If weight is set to 0, no
+traffic should be forwarded for this entry. If unspecified, weight
+defaults to 1.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2490,10 +2493,8 @@ If unspecified, weight defaults to 1.</p>
 <em>(Optional)</em>
 <p>Filters defined at this-level should be executed if and only if the
 request is being forwarded to the backend defined here.</p>
-<p>Conformance: Filtering support, including core filters, is NOT guaranteed
-at this-level. Use Filters in HTTPRouteRule for portable filters across
-implementations.</p>
-<p>Support: Custom</p>
+<p>Support: Custom (For broader support of filters, use the Filters field
+in HTTPRouteRule.)</p>
 </td>
 </tr>
 </tbody>
@@ -2646,13 +2647,13 @@ HTTP request.</p>
 <em>(Optional)</em>
 <p>Filters define the filters that are applied to requests that match
 this rule.</p>
-<p>The effects of ordering of multiple behaviors are currently undefined.
+<p>The effects of ordering of multiple behaviors are currently unspecified.
 This can change in the future based on feedback during the alpha stage.</p>
 <p>Conformance-levels at this level are defined based on the type of filter:
 - ALL core filters MUST be supported by all implementations.
 - Implementers are encouraged to support extended filters.
 - Implementation-specific custom filters have no API guarantees across implementations.
-Specifying a core filter multiple times has undefined or custom conformance.</p>
+Specifying a core filter multiple times has unspecified or custom conformance.</p>
 <p>Support: core</p>
 </td>
 </tr>
@@ -3249,7 +3250,7 @@ kind: HTTPRoute</p>
 group:</p>
 <p>routes:
 group: acme.io
-resource: fooroutes</p>
+kind: FooRoute</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -3362,13 +3363,16 @@ int32
 </em>
 </td>
 <td>
-<p>Weight specifies the proportion of traffic forwarded to the backend
-referenced by the ServiceName or BackendRef field. computed as
-weight/(sum of all weights in this ForwardTo list). Weight is not a
-percentage and the sum of weights does not need to equal 100. If only one
-backend is specified, 100% of the traffic is forwarded to that backend.
-If weight is set to 0, no traffic should be forwarded for this entry.
-If unspecified, weight defaults to 1.</p>
+<p>Weight specifies the proportion of HTTP requests forwarded to the backend
+referenced by the ServiceName or BackendRef field. This is computed as
+weight/(sum of all weights in this ForwardTo list). For non-zero values,
+there may be some epsilon from the exact proportion defined here
+depending on the precision an implementation supports. Weight is not a
+percentage and the sum of weights does not need to equal 100.</p>
+<p>If only one backend is specified and it has a weight greater than 0, 100%
+of the traffic is forwarded to that backend. If weight is set to 0, no
+traffic should be forwarded for this entry. If unspecified, weight
+defaults to 1.</p>
 <p>Support: Extended</p>
 </td>
 </tr>
@@ -3584,6 +3588,9 @@ Gateways. When a Gateway selects this route, the controller that
 manages the Gateway should add an entry to this list when the
 controller first sees the route and should update the entry as
 appropriate when the route is modified.</p>
+<p>A maximum of 100 Gateways will be represented in this list. If this list
+is full, there may be additional Gateways using this Route that are not
+included in the list.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
- Add an upper limit of 100 to the number of Gateways that will be stored in RouteGatewayStatus.
- Clarify support level of filters defined in ForwardTo.
- Increase max weight to 1 million.
- Clarify how 1 backend with a weight of 0 should be handled.
- Replace "undefined" with "unspecified"
- resource: fooroutes -> kind: FooRoute

Fixes https://github.com/kubernetes-sigs/service-apis/issues/435

/cc @danehans @hbagdi @jpeach 