### PR TITLE
change max items from 10 to 16 for snis in TLSRoute

### DIFF
--- a/apis/v1alpha1/tlsroute_types.go
+++ b/apis/v1alpha1/tlsroute_types.go
@@ -95,7 +95,7 @@ type TLSRouteMatch struct {
 	// Support: core
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=10
+	// +kubebuilder:validation:MaxItems=16
 	SNIs []string `json:"snis,omitempty"`
 	// ExtensionRef is an optional, implementation-specific extension to the
 	// "match" behavior.  The resource may be "configmap" (use the empty

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -153,7 +153,7 @@ spec:
                             description: "SNIs defines a set of SNI names that should match against the SNI attribute of TLS CLientHello message in TLS handshake. \n SNI can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.example.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). Requests will be matched against the Host field in the following order: \n 1. If SNI is precise, the request matches this rule if    the SNI in ClientHello is equal to one of the defined SNIs. 2. If SNI is a wildcard, then the request matches this rule if    the SNI is to equal to the suffix    (removing the first label) of the wildcard rule. \n Support: core"
                             items:
                               type: string
-                            maxItems: 10
+                            maxItems: 16
                             minItems: 1
                             type: array
                         type: object


### PR DESCRIPTION
All of our `MaxItems` limits are a power of 2.
This patch has doesn't add much value to the API other than having consistency.