### PR TITLE
Adding changelog for v0.1.0-rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,53 @@
-# Table of Contents
+# Changelog
 
-- [v0.1.0](#v010)
+## Table of Contents
+
+- [v0.1.0-rc2](#v010-rc2)
+- [v0.1.0-rc1](#v010-rc1)
+
+## v0.1.0-rc2
+
+API Version: v1alpha-rc2
+
+### API changes since v0.1.0-rc1
+#### GatewayClass
+- A recommendation to set a `gateway-exists-finalizer.networking.x-k8s.io`
+  finalizer on GatewayClass has been added.
+- `allowedGatewayNamespaces` has been removed from GatewayClass in favor of
+  implementations with policy agents like Gatekeeper.
+
+#### Gateway
+- Fields in `listeners.routes` have been renamed:
+  - `routes.routeSelector` -> `routes.selector`
+  - `routes.routeNamespaces`-> `routes.namespaces`
+- `clientCertificateRef` has been removed from BackendPolicy.
+- In Listeners, `routes.namespaces` now defaults to `{from: "Same"}`.
+- In Listeners, support has been added for specifying custom, domain prefixed
+  protocols.
+- In Listeners, `hostname` now closely matches Route hostname matching with wildcard
+  support.
+- A new `UnsupportedAddress` condition has been added to Listeners to indicate
+  that a requested address is not supported.
+- Clarification has been added to note that listeners may be merged in certain
+  instances.
+
+#### Routes
+- HeaderMatchType now includes a RegularExpression option.
+- Minimum weight has been decreased from 1 to 0.
+- Port is now required on all Routes.
+- On HTTPRoute, filters have been renamed:
+  - `ModifyRequestHeader` -> `RequestHeaderModifier`
+  - `MirrorRequest` -> `RequestMirror`
+  - `Custom` -> `ExtensionRef`
+- TLSRoute can now specify as many as 16 SNIs instead of 10.
+- Limiting the number of Gateways that may be stored in RouteGatewayStatus to
+  100.
+- Support level of filters defined in ForwardTo has been clarified.
+- Max weight has been increased to 1 million.
 
 
-## v0.1.0
+## v0.1.0-rc1
 
-TBD
+API Version: v1alpha-rc1
+
+- Initial release candidate for v1alpha1.


### PR DESCRIPTION
When this PR merges I'll cut RC2. Ideally I'd like to get https://github.com/kubernetes-sigs/service-apis/pull/416 and https://github.com/kubernetes-sigs/service-apis/pull/436 in first, but understand if there's still some hesitation on one or both of those PRs.

/cc @bowei @danehans @hbagdi @jpeach 
/hold for an hour or two to see if other PRs can get in first