### PR TITLE
Various v1alpha1 API Clean-Up

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -230,11 +230,6 @@ type Listener struct {
 	Routes RouteBindingSelector `json:"routes"`
 }
 
-// Hostname is used to specify a hostname that should be matched.
-// +kubebuilder:validation:MinLength=1
-// +kubebuilder:validation:MaxLength=253
-type Hostname string
-
 // ProtocolType defines the application protocol accepted by a Listener.
 // Implementations are not required to accept all the defined protocols.
 // If an implementation does not support a specified protocol, it
@@ -752,7 +747,7 @@ const (
 	//
 	// Possible reasons for this condition to be false are:
 	//
-	// * "DroppedRoutes"
+	// * "DegradedRoutes"
 	// * "InvalidCertificateRef"
 	// * "InvalidRoutesRef"
 	//
@@ -761,11 +756,11 @@ const (
 	// interoperability.
 	ListenerConditionResolvedRefs ListenerConditionType = "ResolvedRefs"
 
-	// ListenerReasonDroppedRoutes indicates that not all of the routes
-	// selected by this Listener could be configured. The specific
-	// reason why each route was dropped should be indicated in the
-	// route's .Status.Conditions field.
-	ListenerReasonDroppedRoutes ListenerConditionReason = "DroppedRoutes"
+	// ListenerReasonDegradedRoutes indicates that not all of the routes
+	// selected by this Listener could be configured. The specific reason
+	// for the degraded route should be indicated in the route's
+	// .Status.Conditions field.
+	ListenerReasonDegradedRoutes ListenerConditionReason = "DegradedRoutes"
 
 	// ListenerReasonInvalidCertificateRef is used when the
 	// Listener has a TLS configuration with a TLS CertificateRef

--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -174,7 +174,9 @@ type HTTPRouteRule struct {
 	// Conformance-levels at this level are defined based on the type of filter:
 	// - ALL core filters MUST be supported by all implementations.
 	// - Implementers are encouraged to support extended filters.
-	// - Implementation-specific custom filters have no API guarantees across implementations.
+	// - Implementation-specific custom filters have no API guarantees across
+	//   implementations.
+	//
 	// Specifying a core filter multiple times has unspecified or custom conformance.
 	//
 	// Support: core
@@ -184,6 +186,10 @@ type HTTPRouteRule struct {
 	Filters []HTTPRouteFilter `json:"filters,omitempty"`
 
 	// ForwardTo defines the backend(s) where matching requests should be sent.
+	// If unspecified, the rule performs no forwarding. If unspecified and no
+	// filters are specified that would result in a response being sent, a 503
+	// error code is returned.
+	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=4
 	ForwardTo []HTTPRouteForwardTo `json:"forwardTo,omitempty"`
@@ -304,12 +310,12 @@ type HTTPRouteMatch struct {
 	Headers *HTTPHeaderMatch `json:"headers"`
 
 	// ExtensionRef is an optional, implementation-specific extension to the
-	// "match" behavior.  For example, resource "myroutematcher" in group
-	// "networking.acme.io". If the referent cannot be found, the route must
-	// be dropped from the Gateway. The controller should raise the
-	// "ResolvedRefs" condition on the Gateway with the "DroppedRoutes"
-	// reason. The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// "match" behavior. For example, resource "myroutematcher" in group
+	// "networking.acme.io". If the referent cannot be found, the rule is not
+	// included in the route. The controller should raise the "ResolvedRefs"
+	// condition on the Gateway with the "DegradedRoutes" reason. The gateway
+	// status for this route should be updated with a condition that describes
+	// the error more specifically.
 	//
 	// Support: custom
 	//
@@ -457,11 +463,10 @@ type HTTPRequestMirrorFilter struct {
 	// BackendRef and ServiceName are specified, ServiceName will be given
 	// precedence.
 	//
-	// If the referent cannot be found, the route must be dropped
-	// from the Gateway. The controller should raise the "ResolvedRefs"
-	// condition on the Gateway with the "DroppedRoutes" reason.
-	// The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// If the referent cannot be found, the rule is not included in the route.
+	// The controller should raise the "ResolvedRefs" condition on the Gateway
+	// with the "DegradedRoutes" reason. The gateway status for this route should
+	// be updated with a condition that describes the error more specifically.
 	//
 	// Support: Core
 	//
@@ -473,11 +478,10 @@ type HTTPRequestMirrorFilter struct {
 	// both BackendRef and ServiceName are specified, ServiceName will be given
 	// precedence.
 	//
-	// If the referent cannot be found, the route must be dropped
-	// from the Gateway. The controller should raise the "ResolvedRefs"
-	// condition on the Gateway with the "DroppedRoutes" reason.
-	// The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// If the referent cannot be found, the rule is not included in the route.
+	// The controller should raise the "ResolvedRefs" condition on the Gateway
+	// with the "DegradedRoutes" reason. The gateway status for this route should
+	// be updated with a condition that describes the error more specifically.
 	//
 	// Support: Custom
 	//

--- a/apis/v1alpha1/shared_types.go
+++ b/apis/v1alpha1/shared_types.go
@@ -97,11 +97,10 @@ type RouteForwardTo struct {
 	// BackendRef and ServiceName are specified, ServiceName will be given
 	// precedence.
 	//
-	// If the referent cannot be found, the route must be dropped
-	// from the Gateway. The controller should raise the "ResolvedRefs"
-	// condition on the Gateway with the "DroppedRoutes" reason.
-	// The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// If the referent cannot be found, the rule is not included in the route.
+	// The controller should raise the "ResolvedRefs" condition on the Gateway
+	// with the "DegradedRoutes" reason. The gateway status for this route should
+	// be updated with a condition that describes the error more specifically.
 	//
 	// The protocol to use is defined using AppProtocol field (introduced in
 	// Kubernetes 1.18) in the Service resource. In the absence of the
@@ -122,11 +121,10 @@ type RouteForwardTo struct {
 	// both BackendRef and ServiceName are specified, ServiceName will be given
 	// precedence.
 	//
-	// If the referent cannot be found, the route must be dropped
-	// from the Gateway. The controller should raise the "ResolvedRefs"
-	// condition on the Gateway with the "DroppedRoutes" reason.
-	// The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// If the referent cannot be found, the rule is not included in the route.
+	// The controller should raise the "ResolvedRefs" condition on the Gateway
+	// with the "DegradedRoutes" reason. The gateway status for this route should
+	// be updated with a condition that describes the error more specifically.
 	//
 	//
 	// Support: Custom
@@ -204,3 +202,8 @@ type RouteStatus struct {
 	// +kubebuilder:validation:MaxItems=100
 	Gateways []RouteGatewayStatus `json:"gateways"`
 }
+
+// Hostname is used to specify a hostname that should be matched.
+// +kubebuilder:validation:MinLength=1
+// +kubebuilder:validation:MaxLength=253
+type Hostname string

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -36,9 +36,13 @@ type TCPRoute struct {
 // TCPRouteSpec defines the desired state of TCPRoute
 type TCPRouteSpec struct {
 	// Rules are a list of TCP matchers and actions.
+	//
+	// +kubebuilder:validation:MinItems=1
+	// +kubebuilder:validation:MaxItems=16
 	Rules []TCPRouteRule `json:"rules"`
 
 	// Gateways defines which Gateways can use this Route.
+	//
 	// +kubebuilder:default={allow: "SameNamespace"}
 	Gateways RouteGateways `json:"gateways,omitempty"`
 }
@@ -51,35 +55,33 @@ type TCPRouteStatus struct {
 // TCPRouteRule is the configuration for a given rule.
 type TCPRouteRule struct {
 	// Matches define conditions used for matching the rule against
-	// incoming TCP connections.
-	// Each match is independent, i.e. this rule will be matched
-	// if **any** one of the matches is satisfied.
+	// incoming TCP connections. Each match is independent, i.e. this
+	// rule will be matched if **any** one of the matches is satisfied.
+	// If unspecified, all requests from the associated gateway TCP
+	// listener will match.
 	//
 	// +optional
 	// +kubebuilder:validation:MaxItems=8
 	Matches []TCPRouteMatch `json:"matches,omitempty"`
 
-	// ForwardTo defines the backend(s) where matching requests should be sent.
-	// +optional
+	// ForwardTo defines the backend(s) where matching requests should
+	// be sent.
+	//
+	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=4
-	ForwardTo []RouteForwardTo `json:"forwardTo,omitempty"`
+	ForwardTo []RouteForwardTo `json:"forwardTo"`
 }
 
 // TCPRouteMatch defines the predicate used to match connections to a
 // given action.
 type TCPRouteMatch struct {
 	// ExtensionRef is an optional, implementation-specific extension to the
-	// "match" behavior.  The resource may be "configmap" (use the empty
-	// string for the group) or an implementation-defined resource (for
-	// example, resource "myroutematchers" in group "networking.acme.io").
-	// Omitting or specifying the empty string for both the resource and
-	// group indicates that the resource is "configmaps".
-	//
-	// If the referent cannot be found, the route must be dropped
-	// from the Gateway. The controller should raise the "ResolvedRefs"
-	// condition on the Gateway with the "DroppedRoutes" reason.
-	// The gateway status for this route should be updated with a
-	// condition that describes the error more specifically.
+	// "match" behavior.  For example, resource "mytcproutematcher" in group
+	// "networking.acme.io". If the referent cannot be found, the rule is not
+	// included in the route. The controller should raise the "ResolvedRefs"
+	// condition on the Gateway with the "DegradedRoutes" reason. The gateway
+	// status for this route should be updated with a condition that describes
+	// the error more specifically.
 	//
 	// Support: custom
 	//

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1208,7 +1208,7 @@ func (in *TLSRouteMatch) DeepCopyInto(out *TLSRouteMatch) {
 	*out = *in
 	if in.SNIs != nil {
 		in, out := &in.SNIs, &out.SNIs
-		*out = make([]string, len(*in))
+		*out = make([]Hostname, len(*in))
 		copy(*out, *in)
 	}
 	if in.ExtensionRef != nil {

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -85,7 +85,7 @@ spec:
                   description: HTTPRouteRule defines semantics for matching an incoming HTTP request against a set of matching rules and executing an action (and optionally filters) on the request.
                   properties:
                     filters:
-                      description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently unspecified. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across implementations. Specifying a core filter multiple times has unspecified or custom conformance. \n Support: core"
+                      description: "Filters define the filters that are applied to requests that match this rule. \n The effects of ordering of multiple behaviors are currently unspecified. This can change in the future based on feedback during the alpha stage. \n Conformance-levels at this level are defined based on the type of filter: - ALL core filters MUST be supported by all implementations. - Implementers are encouraged to support extended filters. - Implementation-specific custom filters have no API guarantees across   implementations. \n Specifying a core filter multiple times has unspecified or custom conformance. \n Support: core"
                       items:
                         description: 'HTTPRouteFilter defines additional processing steps that must be completed during the request or response lifecycle. HTTPRouteFilters are meant as an extension point to express additional processing that may be done in Gateway implementations. Some examples include request or response modification, implementing authentication strategies, rate-limiting, and traffic shaping. API guarantee/conformance is defined based on the type of the filter. TODO(hbagdi): re-render CRDs once controller-tools supports union tags: - https://github.com/kubernetes-sigs/controller-tools/pull/298 - https://github.com/kubernetes-sigs/controller-tools/issues/461'
                         properties:
@@ -131,7 +131,7 @@ spec:
                             description: "RequestMirror defines a schema for a filter that mirrors requests. \n Support: Extended"
                             properties:
                               backendRef:
-                                description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                                description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
                                 properties:
                                   group:
                                     description: Group is the group of the referent.
@@ -160,7 +160,7 @@ spec:
                                 minimum: 1
                                 type: integer
                               serviceName:
-                                description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
+                                description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
                                 maxLength: 253
                                 type: string
                             required:
@@ -179,7 +179,7 @@ spec:
                       maxItems: 16
                       type: array
                     forwardTo:
-                      description: ForwardTo defines the backend(s) where matching requests should be sent.
+                      description: ForwardTo defines the backend(s) where matching requests should be sent. If unspecified, the rule performs no forwarding. If unspecified and no filters are specified that would result in a response being sent, a 503 error code is returned.
                       items:
                         description: HTTPRouteForwardTo defines how a HTTPRoute should forward a request.
                         properties:
@@ -253,7 +253,7 @@ spec:
                                   description: "RequestMirror defines a schema for a filter that mirrors requests. \n Support: Extended"
                                   properties:
                                     backendRef:
-                                      description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                                      description: "BackendRef is a local object reference to mirror matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
                                       properties:
                                         group:
                                           description: Group is the group of the referent.
@@ -282,7 +282,7 @@ spec:
                                       minimum: 1
                                       type: integer
                                     serviceName:
-                                      description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
+                                      description: "ServiceName refers to the name of the Service to mirror matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Core"
                                       maxLength: 253
                                       type: string
                                   required:
@@ -332,7 +332,7 @@ spec:
                         description: "HTTPRouteMatch defines the predicate used to match requests to a given action. Multiple match types are ANDed together, i.e. the match will evaluate to true only if all conditions are satisfied. \n For example, the match below will match a HTTP request only if its path starts with `/foo` AND it contains the `version: \"1\"` header: \n ``` match:   path:     value: \"/foo\"   headers:     values:       version: \"1\" ```"
                         properties:
                           extensionRef:
-                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"myroutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
+                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior. For example, resource \"myroutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -77,7 +77,7 @@ spec:
                         description: RouteForwardTo defines how a Route should forward a request.
                         properties:
                           backendRef:
-                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -106,7 +106,7 @@ spec:
                             minimum: 1
                             type: integer
                           serviceName:
-                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
+                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
                             maxLength: 253
                             type: string
                           weight:
@@ -120,14 +120,15 @@ spec:
                         - port
                         type: object
                       maxItems: 4
+                      minItems: 1
                       type: array
                     matches:
-                      description: Matches define conditions used for matching the rule against incoming TCP connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.
+                      description: Matches define conditions used for matching the rule against incoming TCP connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified, all requests from the associated gateway TCP listener will match.
                       items:
                         description: TCPRouteMatch defines the predicate used to match connections to a given action.
                         properties:
                           extensionRef:
-                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  The resource may be \"configmap\" (use the empty string for the group) or an implementation-defined resource (for example, resource \"myroutematchers\" in group \"networking.acme.io\"). Omitting or specifying the empty string for both the resource and group indicates that the resource is \"configmaps\". \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
+                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"mytcproutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -152,7 +153,11 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                  required:
+                  - forwardTo
                   type: object
+                maxItems: 16
+                minItems: 1
                 type: array
             required:
             - rules

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -19,7 +19,7 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: "TLSRoute is the Schema for the TLSRoute resource. TLSRoute is similar to TCPRoute but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for in a given TLS listener. \n If you need to forward traffic to a single target for a TLS listener, you could chose to use a TCPRoute with a TLS listener."
+        description: "TLSRoute is the Schema for the TLSRoute resource. TLSRoute is similar to TCPRoute but can be configured to match against TLS-specific metadata. This allows more flexibility in matching streams for a given TLS listener. \n If you need to forward traffic to a single target for a TLS listener, you could chose to use a TCPRoute with a TLS listener."
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -77,7 +77,7 @@ spec:
                         description: RouteForwardTo defines how a Route should forward a request.
                         properties:
                           backendRef:
-                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -106,7 +106,7 @@ spec:
                             minimum: 1
                             type: integer
                           serviceName:
-                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
+                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
                             maxLength: 253
                             type: string
                           weight:
@@ -120,14 +120,15 @@ spec:
                         - port
                         type: object
                       maxItems: 4
+                      minItems: 1
                       type: array
                     matches:
-                      description: Matches define conditions used for matching the rule against incoming TLS handshake. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied.
+                      description: Matches define conditions used for matching the rule against an incoming TLS handshake. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified, all requests from the associated gateway TLS listener will match.
                       items:
                         description: TLSRouteMatch defines the predicate used to match connections to a given action.
                         properties:
                           extensionRef:
-                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  The resource may be \"configmap\" (use the empty string for the group) or an implementation-defined resource (for example, resource \"myroutematchers\" in group \"networking.acme.io\"). Omitting or specifying the empty string for both the resource and group indicates that the resource is \"configmaps\". \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
+                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"mytlsroutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -150,15 +151,19 @@ spec:
                             - name
                             type: object
                           snis:
-                            description: "SNIs defines a set of SNI names that should match against the SNI attribute of TLS CLientHello message in TLS handshake. \n SNI can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.example.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). Requests will be matched against the Host field in the following order: \n 1. If SNI is precise, the request matches this rule if    the SNI in ClientHello is equal to one of the defined SNIs. 2. If SNI is a wildcard, then the request matches this rule if    the SNI is to equal to the suffix    (removing the first label) of the wildcard rule. \n Support: core"
+                            description: "SNIs defines a set of SNI names that should match against the SNI attribute of TLS ClientHello message in TLS handshake. \n SNI can be \"precise\" which is a domain name without the terminating dot of a network host (e.g. \"foo.example.com\") or \"wildcard\", which is a domain name prefixed with a single wildcard label (e.g. \"*.example.com\"). The wildcard character '*' must appear by itself as the first DNS label and matches only a single label. You cannot have a wildcard label by itself (e.g. Host == \"*\"). \n Requests will be matched against the Host field in the following order: \n 1. If SNI is precise, the request matches this rule if the SNI in    ClientHello is equal to one of the defined SNIs. 2. If SNI is a wildcard, then the request matches this rule if the    SNI is to equal to the suffix (removing the first label) of the    wildcard rule. 3. If SNIs is unspecified, all requests associated with the gateway TLS    listener will match. This can be used to define a default backend    for a TLS listener. \n Support: core"
                             items:
+                              description: Hostname is used to specify a hostname that should be matched.
+                              maxLength: 253
+                              minLength: 1
                               type: string
                             maxItems: 16
-                            minItems: 1
                             type: array
                         type: object
                       maxItems: 8
                       type: array
+                  required:
+                  - forwardTo
                   type: object
                 maxItems: 16
                 minItems: 1

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -77,7 +77,7 @@ spec:
                         description: RouteForwardTo defines how a Route should forward a request.
                         properties:
                           backendRef:
-                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
+                            description: "BackendRef is a reference to a backend to forward matched requests to. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: Custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -106,7 +106,7 @@ spec:
                             minimum: 1
                             type: integer
                           serviceName:
-                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
+                            description: "ServiceName refers to the name of the Service to forward matched requests to. When specified, this takes the place of BackendRef. If both BackendRef and ServiceName are specified, ServiceName will be given precedence. \n If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n The protocol to use is defined using AppProtocol field (introduced in Kubernetes 1.18) in the Service resource. In the absence of the AppProtocol field a `networking.x-k8s.io/app-protocol` annotation on the BackendPolicy resource may be used to define the protocol. If the AppProtocol field is available, this annotation should not be used. The AppProtocol field, when populated, takes precedence over the annotation in the BackendPolicy resource. For custom backends, it is encouraged to add a semantically-equivalent field in the Custom Resource Definition. \n Support: Core"
                             maxLength: 253
                             type: string
                           weight:
@@ -120,14 +120,15 @@ spec:
                         - port
                         type: object
                       maxItems: 4
+                      minItems: 1
                       type: array
                     matches:
-                      description: Matches defines which packets match this rule.
+                      description: Matches define conditions used for matching the rule against incoming UDP connections. Each match is independent, i.e. this rule will be matched if **any** one of the matches is satisfied. If unspecified, all requests from the associated gateway UDP listener will match.
                       items:
                         description: UDPRouteMatch defines the predicate used to match packets to a given action.
                         properties:
                           extensionRef:
-                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  The resource may be \"configmap\" (use the empty string for the group) or an implementation-defined resource (for example, resource \"myroutematchers\" in group \"networking.acme.io\"). Omitting or specifying the empty string for both the resource and group indicates that the resource is \"configmaps\". \n If the referent cannot be found, the route must be dropped from the Gateway. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DroppedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
+                            description: "ExtensionRef is an optional, implementation-specific extension to the \"match\" behavior.  For example, resource \"myudproutematcher\" in group \"networking.acme.io\". If the referent cannot be found, the rule is not included in the route. The controller should raise the \"ResolvedRefs\" condition on the Gateway with the \"DegradedRoutes\" reason. The gateway status for this route should be updated with a condition that describes the error more specifically. \n Support: custom"
                             properties:
                               group:
                                 description: Group is the group of the referent.
@@ -152,7 +153,11 @@ spec:
                         type: object
                       maxItems: 8
                       type: array
+                  required:
+                  - forwardTo
                   type: object
+                maxItems: 16
+                minItems: 1
                 type: array
             required:
             - rules

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -680,10 +680,9 @@ TCPRouteStatus
 <h3 id="networking.x-k8s.io/v1alpha1.TLSRoute">TLSRoute
 </h3>
 <p>
-<p>TLSRoute is the Schema for the TLSRoute resource.
-TLSRoute is similar to TCPRoute but can be configured to match against
-TLS-specific metadata.
-This allows more flexibility in matching streams for in a given TLS listener.</p>
+<p>TLSRoute is the Schema for the TLSRoute resource. TLSRoute is similar to
+TCPRoute but can be configured to match against TLS-specific metadata.
+This allows more flexibility in matching streams for a given TLS listener.</p>
 <p>If you need to forward traffic to a single target for a TLS listener, you
 could chose to use a TCPRoute with a TLS listener.</p>
 </p>
@@ -1799,11 +1798,10 @@ string
 to. When specified, this takes the place of BackendRef. If both
 BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -1821,11 +1819,10 @@ LocalObjectReference
 <p>BackendRef is a local object reference to mirror matched requests to. If
 both BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Custom</p>
 </td>
 </tr>
@@ -2152,12 +2149,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  For example, resource &ldquo;myroutematcher&rdquo; in group
-&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the route must
-be dropped from the Gateway. The controller should raise the
-&ldquo;ResolvedRefs&rdquo; condition on the Gateway with the &ldquo;DroppedRoutes&rdquo;
-reason. The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior. For example, resource &ldquo;myroutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -2237,8 +2234,9 @@ This can change in the future based on feedback during the alpha stage.</p>
 <p>Conformance-levels at this level are defined based on the type of filter:
 - ALL core filters MUST be supported by all implementations.
 - Implementers are encouraged to support extended filters.
-- Implementation-specific custom filters have no API guarantees across implementations.
-Specifying a core filter multiple times has unspecified or custom conformance.</p>
+- Implementation-specific custom filters have no API guarantees across
+implementations.</p>
+<p>Specifying a core filter multiple times has unspecified or custom conformance.</p>
 <p>Support: core</p>
 </td>
 </tr>
@@ -2253,7 +2251,10 @@ Specifying a core filter multiple times has unspecified or custom conformance.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should be sent.
+If unspecified, the rule performs no forwarding. If unspecified and no
+filters are specified that would result in a response being sent, a 503
+error code is returned.</p>
 </td>
 </tr>
 </tbody>
@@ -2422,7 +2423,8 @@ Valid HeaderMatchType values are:</p>
 <p>
 (<em>Appears on:</em>
 <a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">HTTPRouteSpec</a>, 
-<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>)
+<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.TLSRouteMatch">TLSRouteMatch</a>)
 </p>
 <p>
 <p>Hostname is used to specify a hostname that should be matched.</p>
@@ -2895,11 +2897,10 @@ string
 to. When specified, this takes the place of BackendRef. If both
 BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>The protocol to use is defined using AppProtocol field (introduced in
 Kubernetes 1.18) in the Service resource. In the absence of the
 AppProtocol field a <code>networking.x-k8s.io/app-protocol</code> annotation on the
@@ -2925,11 +2926,10 @@ LocalObjectReference
 <p>BackendRef is a reference to a backend to forward matched requests to. If
 both BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Custom</p>
 </td>
 </tr>
@@ -3259,16 +3259,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;mytcproutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -3303,9 +3299,10 @@ condition that describes the error more specifically.</p>
 <td>
 <em>(Optional)</em>
 <p>Matches define conditions used for matching the rule against
-incoming TCP connections.
-Each match is independent, i.e. this rule will be matched
-if <strong>any</strong> one of the matches is satisfied.</p>
+incoming TCP connections. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway TCP
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -3318,8 +3315,8 @@ if <strong>any</strong> one of the matches is satisfied.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should
+be sent.</p>
 </td>
 </tr>
 </tbody>
@@ -3471,25 +3468,31 @@ given action.</p>
 <td>
 <code>snis</code></br>
 <em>
-[]string
+<a href="#networking.x-k8s.io/v1alpha1.Hostname">
+[]Hostname
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SNIs defines a set of SNI names that should match against the
-SNI attribute of TLS CLientHello message in TLS handshake.</p>
+SNI attribute of TLS ClientHello message in TLS handshake.</p>
 <p>SNI can be &ldquo;precise&rdquo; which is a domain name without the terminating
 dot of a network host (e.g. &ldquo;foo.example.com&rdquo;) or &ldquo;wildcard&rdquo;, which is
 a domain name prefixed with a single wildcard label (e.g. &ldquo;<em>.example.com&rdquo;).
-The wildcard character &lsquo;</em>&rsquo; must appear by itself as the first DNS
-label and matches only a single label.
-You cannot have a wildcard label by itself (e.g. Host == &ldquo;*&rdquo;).
-Requests will be matched against the Host field in the following order:</p>
+The wildcard character &lsquo;</em>&rsquo; must appear by itself as the first DNS label
+and matches only a single label. You cannot have a wildcard label by
+itself (e.g. Host == &ldquo;*&rdquo;).</p>
+<p>Requests will be matched against the Host field in the following order:</p>
 <ol>
-<li>If SNI is precise, the request matches this rule if
-the SNI in ClientHello is equal to one of the defined SNIs.</li>
-<li>If SNI is a wildcard, then the request matches this rule if
-the SNI is to equal to the suffix
-(removing the first label) of the wildcard rule.</li>
+<li>If SNI is precise, the request matches this rule if the SNI in
+ClientHello is equal to one of the defined SNIs.</li>
+<li>If SNI is a wildcard, then the request matches this rule if the
+SNI is to equal to the suffix (removing the first label) of the
+wildcard rule.</li>
+<li>If SNIs is unspecified, all requests associated with the gateway TLS
+listener will match. This can be used to define a default backend
+for a TLS listener.</li>
 </ol>
 <p>Support: core</p>
 </td>
@@ -3506,16 +3509,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;mytlsroutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -3559,10 +3558,11 @@ to override a specific TLS setting.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Matches define conditions used for matching the rule against
-incoming TLS handshake.
-Each match is independent, i.e. this rule will be matched
-if <strong>any</strong> one of the matches is satisfied.</p>
+<p>Matches define conditions used for matching the rule against an
+incoming TLS handshake. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway TLS
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -3575,8 +3575,8 @@ if <strong>any</strong> one of the matches is satisfied.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should be
+sent.</p>
 </td>
 </tr>
 </tbody>
@@ -3690,16 +3690,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;myudproutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -3733,7 +3729,11 @@ condition that describes the error more specifically.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Matches defines which packets match this rule.</p>
+<p>Matches define conditions used for matching the rule against
+incoming UDP connections. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway UDP
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -3746,8 +3746,8 @@ condition that describes the error more specifically.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should
+be sent.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -1115,10 +1115,9 @@ TCPRouteStatus
 <h3 id="networking.x-k8s.io/v1alpha1.TLSRoute">TLSRoute
 </h3>
 <p>
-<p>TLSRoute is the Schema for the TLSRoute resource.
-TLSRoute is similar to TCPRoute but can be configured to match against
-TLS-specific metadata.
-This allows more flexibility in matching streams for in a given TLS listener.</p>
+<p>TLSRoute is the Schema for the TLSRoute resource. TLSRoute is similar to
+TCPRoute but can be configured to match against TLS-specific metadata.
+This allows more flexibility in matching streams for a given TLS listener.</p>
 <p>If you need to forward traffic to a single target for a TLS listener, you
 could chose to use a TCPRoute with a TLS listener.</p>
 </p>
@@ -2234,11 +2233,10 @@ string
 to. When specified, this takes the place of BackendRef. If both
 BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Core</p>
 </td>
 </tr>
@@ -2256,11 +2254,10 @@ LocalObjectReference
 <p>BackendRef is a local object reference to mirror matched requests to. If
 both BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Custom</p>
 </td>
 </tr>
@@ -2587,12 +2584,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  For example, resource &ldquo;myroutematcher&rdquo; in group
-&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the route must
-be dropped from the Gateway. The controller should raise the
-&ldquo;ResolvedRefs&rdquo; condition on the Gateway with the &ldquo;DroppedRoutes&rdquo;
-reason. The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior. For example, resource &ldquo;myroutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -2672,8 +2669,9 @@ This can change in the future based on feedback during the alpha stage.</p>
 <p>Conformance-levels at this level are defined based on the type of filter:
 - ALL core filters MUST be supported by all implementations.
 - Implementers are encouraged to support extended filters.
-- Implementation-specific custom filters have no API guarantees across implementations.
-Specifying a core filter multiple times has unspecified or custom conformance.</p>
+- Implementation-specific custom filters have no API guarantees across
+implementations.</p>
+<p>Specifying a core filter multiple times has unspecified or custom conformance.</p>
 <p>Support: core</p>
 </td>
 </tr>
@@ -2688,7 +2686,10 @@ Specifying a core filter multiple times has unspecified or custom conformance.</
 </td>
 <td>
 <em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should be sent.
+If unspecified, the rule performs no forwarding. If unspecified and no
+filters are specified that would result in a response being sent, a 503
+error code is returned.</p>
 </td>
 </tr>
 </tbody>
@@ -2857,7 +2858,8 @@ Valid HeaderMatchType values are:</p>
 <p>
 (<em>Appears on:</em>
 <a href="#networking.x-k8s.io/v1alpha1.HTTPRouteSpec">HTTPRouteSpec</a>, 
-<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>)
+<a href="#networking.x-k8s.io/v1alpha1.Listener">Listener</a>, 
+<a href="#networking.x-k8s.io/v1alpha1.TLSRouteMatch">TLSRouteMatch</a>)
 </p>
 <p>
 <p>Hostname is used to specify a hostname that should be matched.</p>
@@ -3330,11 +3332,10 @@ string
 to. When specified, this takes the place of BackendRef. If both
 BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>The protocol to use is defined using AppProtocol field (introduced in
 Kubernetes 1.18) in the Service resource. In the absence of the
 AppProtocol field a <code>networking.x-k8s.io/app-protocol</code> annotation on the
@@ -3360,11 +3361,10 @@ LocalObjectReference
 <p>BackendRef is a reference to a backend to forward matched requests to. If
 both BackendRef and ServiceName are specified, ServiceName will be given
 precedence.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+<p>If the referent cannot be found, the rule is not included in the route.
+The controller should raise the &ldquo;ResolvedRefs&rdquo; condition on the Gateway
+with the &ldquo;DegradedRoutes&rdquo; reason. The gateway status for this route should
+be updated with a condition that describes the error more specifically.</p>
 <p>Support: Custom</p>
 </td>
 </tr>
@@ -3694,16 +3694,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;mytcproutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -3738,9 +3734,10 @@ condition that describes the error more specifically.</p>
 <td>
 <em>(Optional)</em>
 <p>Matches define conditions used for matching the rule against
-incoming TCP connections.
-Each match is independent, i.e. this rule will be matched
-if <strong>any</strong> one of the matches is satisfied.</p>
+incoming TCP connections. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway TCP
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -3753,8 +3750,8 @@ if <strong>any</strong> one of the matches is satisfied.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should
+be sent.</p>
 </td>
 </tr>
 </tbody>
@@ -3906,25 +3903,31 @@ given action.</p>
 <td>
 <code>snis</code></br>
 <em>
-[]string
+<a href="#networking.x-k8s.io/v1alpha1.Hostname">
+[]Hostname
+</a>
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>SNIs defines a set of SNI names that should match against the
-SNI attribute of TLS CLientHello message in TLS handshake.</p>
+SNI attribute of TLS ClientHello message in TLS handshake.</p>
 <p>SNI can be &ldquo;precise&rdquo; which is a domain name without the terminating
 dot of a network host (e.g. &ldquo;foo.example.com&rdquo;) or &ldquo;wildcard&rdquo;, which is
 a domain name prefixed with a single wildcard label (e.g. &ldquo;<em>.example.com&rdquo;).
-The wildcard character &lsquo;</em>&rsquo; must appear by itself as the first DNS
-label and matches only a single label.
-You cannot have a wildcard label by itself (e.g. Host == &ldquo;</em>&rdquo;).
-Requests will be matched against the Host field in the following order:</p>
+The wildcard character &lsquo;</em>&rsquo; must appear by itself as the first DNS label
+and matches only a single label. You cannot have a wildcard label by
+itself (e.g. Host == &ldquo;</em>&rdquo;).</p>
+<p>Requests will be matched against the Host field in the following order:</p>
 <ol>
-<li>If SNI is precise, the request matches this rule if
-the SNI in ClientHello is equal to one of the defined SNIs.</li>
-<li>If SNI is a wildcard, then the request matches this rule if
-the SNI is to equal to the suffix
-(removing the first label) of the wildcard rule.</li>
+<li>If SNI is precise, the request matches this rule if the SNI in
+ClientHello is equal to one of the defined SNIs.</li>
+<li>If SNI is a wildcard, then the request matches this rule if the
+SNI is to equal to the suffix (removing the first label) of the
+wildcard rule.</li>
+<li>If SNIs is unspecified, all requests associated with the gateway TLS
+listener will match. This can be used to define a default backend
+for a TLS listener.</li>
 </ol>
 <p>Support: core</p>
 </td>
@@ -3941,16 +3944,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;mytlsroutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -3994,10 +3993,11 @@ to override a specific TLS setting.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Matches define conditions used for matching the rule against
-incoming TLS handshake.
-Each match is independent, i.e. this rule will be matched
-if <strong>any</strong> one of the matches is satisfied.</p>
+<p>Matches define conditions used for matching the rule against an
+incoming TLS handshake. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway TLS
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -4010,8 +4010,8 @@ if <strong>any</strong> one of the matches is satisfied.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should be
+sent.</p>
 </td>
 </tr>
 </tbody>
@@ -4125,16 +4125,12 @@ LocalObjectReference
 <td>
 <em>(Optional)</em>
 <p>ExtensionRef is an optional, implementation-specific extension to the
-&ldquo;match&rdquo; behavior.  The resource may be &ldquo;configmap&rdquo; (use the empty
-string for the group) or an implementation-defined resource (for
-example, resource &ldquo;myroutematchers&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Omitting or specifying the empty string for both the resource and
-group indicates that the resource is &ldquo;configmaps&rdquo;.</p>
-<p>If the referent cannot be found, the route must be dropped
-from the Gateway. The controller should raise the &ldquo;ResolvedRefs&rdquo;
-condition on the Gateway with the &ldquo;DroppedRoutes&rdquo; reason.
-The gateway status for this route should be updated with a
-condition that describes the error more specifically.</p>
+&ldquo;match&rdquo; behavior.  For example, resource &ldquo;myudproutematcher&rdquo; in group
+&ldquo;networking.acme.io&rdquo;. If the referent cannot be found, the rule is not
+included in the route. The controller should raise the &ldquo;ResolvedRefs&rdquo;
+condition on the Gateway with the &ldquo;DegradedRoutes&rdquo; reason. The gateway
+status for this route should be updated with a condition that describes
+the error more specifically.</p>
 <p>Support: custom</p>
 </td>
 </tr>
@@ -4168,7 +4164,11 @@ condition that describes the error more specifically.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Matches defines which packets match this rule.</p>
+<p>Matches define conditions used for matching the rule against
+incoming UDP connections. Each match is independent, i.e. this
+rule will be matched if <strong>any</strong> one of the matches is satisfied.
+If unspecified, all requests from the associated gateway UDP
+listener will match.</p>
 </td>
 </tr>
 <tr>
@@ -4181,8 +4181,8 @@ condition that describes the error more specifically.</p>
 </em>
 </td>
 <td>
-<em>(Optional)</em>
-<p>ForwardTo defines the backend(s) where matching requests should be sent.</p>
+<p>ForwardTo defines the backend(s) where matching requests should
+be sent.</p>
 </td>
 </tr>
 </tbody>


### PR DESCRIPTION
- Renames `apis/v1alpha1/route_types.go` to `apis/v1alpha1/types.go` since the defined types are referenced by more than just `xRoute` types, i.e. `Gateway`. 
- Moves `Hostname` from `apis/v1alpha1/gateway_types.go` to `apis/v1alpha1/types.go`.
- Updates `xMatch` godocs  for the various API types.

/assign @robscott @hbagdi @bowei 
/cc @jpeach @Miciah 

Fixes #415 