### PR TITLE
write a guide for routes in multiple namespaces

### DIFF
--- a/docs-src/guides.md
+++ b/docs-src/guides.md
@@ -5,3 +5,4 @@ Please checkout one of the following guides:
 
 - [Getting started](getting-started.md)
 - [Configuring TLS](tls.md)
+- [Routes in multiple namespaces](multiple-ns.md)

--- a/docs-src/multiple-ns.md
+++ b/docs-src/multiple-ns.md
@@ -1,0 +1,37 @@
+# Routes in multiple namespaces
+
+With the Service APIs, a single Gateway can target routes across multiple
+namespaces. 
+
+This guide assumes that you have installed Service APIs CRDs and a conformant
+controller.
+
+In the following example:
+
+- `acme-lb` GatewayClass: The GatewayClass responsible for satisfying Gateway
+  and Route resources.
+- `multi-ns-gateaway` Gateway: The Gateway is configured with a single listener
+  on port 80 which selects routes from **all namespaces** which have the label
+  `product: baz`. Notice how the `routes.namespaces.from` field in the listener
+  is set to `All`.
+- `service-apis-example-ns1` and `service-apis-example-ns2` Namespaces: These
+  are two namespaces in which we route resources are installed.
+- `http-app-1` and `http-app-2` HTTPRoutes: These are two resources that are
+  installed in separate namespaces. These routes will be picked up by
+  `multi-ns-gateway` resource for the following reasons:
+    - Both have the `product: baz` label on them.
+    - `http-app-1` HTTPRoute has `spec.gateways.allow` set to `All`.  The route
+      owner here has opted to allow **all** Gateways in the cluster to bind to
+      this Route.
+    - `http-app-2` HTTPRoute has `spec.gateways.allow` set to `FromList` and
+      contains a reference to the `multi-ns-gateway` in `default` namespace. In
+      this case, no other Gateway can bind to this route.  explictly set this
+      field so that Gateways from other namespaces can target the route.
+
+```
+{% include 'routes-in-multiple-namespaces.yaml' %}
+```
+
+Please note that this guide illustrates this feature for HTTPRoute resource
+only as an example. The same can be accomplished with other route types as
+well.

--- a/docs-src/multiple-ns.md
+++ b/docs-src/multiple-ns.md
@@ -11,22 +11,23 @@ In the following example:
 - `acme-lb` GatewayClass: The GatewayClass responsible for satisfying Gateway
   and Route resources.
 - `multi-ns-gateaway` Gateway: The Gateway is configured with a single listener
-  on port 80 which selects routes from **all namespaces** which have the label
-  `product: baz`. Notice how the `routes.namespaces.from` field in the listener
-  is set to `All`.
+  on port 80 which selects routes that have the label `product: baz` in any
+  namespace.  Notice how the `routes.namespaces.from` field in the listener is
+  set to `All`.
 - `service-apis-example-ns1` and `service-apis-example-ns2` Namespaces: These
-  are two namespaces in which we route resources are installed.
+  are the namespaces in which route resources are instantiated.
 - `http-app-1` and `http-app-2` HTTPRoutes: These are two resources that are
-  installed in separate namespaces. These routes will be picked up by
-  `multi-ns-gateway` resource for the following reasons:
+  installed in separate namespaces. These routes will be bound to Gateway
+  `multi-ns-gateway` for the following reasons:
     - Both have the `product: baz` label on them.
     - `http-app-1` HTTPRoute has `spec.gateways.allow` set to `All`.  The route
-      owner here has opted to allow **all** Gateways in the cluster to bind to
-      this Route.
+      owner has opted to allow **all** Gateways in the cluster to bind to this
+      Route.
     - `http-app-2` HTTPRoute has `spec.gateways.allow` set to `FromList` and
-      contains a reference to the `multi-ns-gateway` in `default` namespace. In
-      this case, no other Gateway can bind to this route.  explictly set this
-      field so that Gateways from other namespaces can target the route.
+      contains a reference to the `multi-ns-gateway` in `default` namespace.
+      This means that only the specified Gateway resource can bind to this
+      route.  Additional Gateways may be added to this list to allow them to
+      bind to this route.
 
 ```
 {% include 'routes-in-multiple-namespaces.yaml' %}

--- a/docs/404.html
+++ b/docs/404.html
@@ -286,6 +286,18 @@
 
 
   <li class="md-nav__item">
+    <a href="/multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="/tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -290,6 +290,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -446,6 +446,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/devguide/index.html
+++ b/docs/devguide/index.html
@@ -290,6 +290,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/enhancement-requests/index.html
+++ b/docs/enhancement-requests/index.html
@@ -290,6 +290,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -290,6 +290,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/getting-started/index.html
+++ b/docs/getting-started/index.html
@@ -351,6 +351,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>
@@ -603,7 +615,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: my-gateway
-  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
@@ -615,7 +626,7 @@ spec:
         matchLabels:
           app: foo
       namespaces:
-        from: &quot;All&quot;
+        from: &quot;Same&quot;
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
@@ -692,13 +703,13 @@ not uninstall these CRDs.</p>
           </a>
         
         
-          <a href="../tls/" title="TLS" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
+          <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
             <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
               <span class="md-flex__ellipsis">
                 <span class="md-footer-nav__direction">
                   Next
                 </span>
-                TLS
+                Multiple namespaces and routes
               </span>
             </div>
             <div class="md-flex__cell md-flex__cell--shrink">

--- a/docs/index.html
+++ b/docs/index.html
@@ -349,6 +349,18 @@
 
 
   <li class="md-nav__item">
+    <a href="multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/multiple-ns/index.html
+++ b/docs/multiple-ns/index.html
@@ -36,7 +36,7 @@
     
     
       
-        <title>Introduction - Kubernetes Service APIs</title>
+        <title>Multiple namespaces and routes - Kubernetes Service APIs</title>
       
     
     
@@ -75,7 +75,7 @@
     <input class="md-toggle" data-md-toggle="search" type="checkbox" id="__search" autocomplete="off">
     <label class="md-overlay" data-md-component="overlay" for="__drawer"></label>
     
-      <a href="#guides" tabindex="1" class="md-skip">
+      <a href="#routes-in-multiple-namespaces" tabindex="1" class="md-skip">
         Skip to content
       </a>
     
@@ -101,7 +101,7 @@
             </span>
             <span class="md-header-nav__topic">
               
-                Introduction
+                Multiple namespaces and routes
               
             </span>
           
@@ -266,20 +266,11 @@
           
           
 
-  
 
-
-  <li class="md-nav__item md-nav__item--active">
-    
-    <input class="md-toggle md-nav__toggle" data-md-toggle="toc" type="checkbox" id="__toc">
-    
-      
-    
-    
-    <a href="./" title="Introduction" class="md-nav__link md-nav__link--active">
+  <li class="md-nav__item">
+    <a href="../guides/" title="Introduction" class="md-nav__link">
       Introduction
     </a>
-    
   </li>
 
         
@@ -299,11 +290,20 @@
           
           
 
+  
 
-  <li class="md-nav__item">
-    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+
+  <li class="md-nav__item md-nav__item--active">
+    
+    <input class="md-toggle md-nav__toggle" data-md-toggle="toc" type="checkbox" id="__toc">
+    
+      
+    
+    
+    <a href="./" title="Multiple namespaces and routes" class="md-nav__link md-nav__link--active">
       Multiple namespaces and routes
     </a>
+    
   </li>
 
         
@@ -472,14 +472,134 @@
               
                 
                 
-                <h1 id="guides">Guides</h1>
-<p>Guides demonstrate and provide examples of how to use the API.
-Please checkout one of the following guides:</p>
+                <h1 id="routes-in-multiple-namespaces">Routes in multiple namespaces</h1>
+<p>With the Service APIs, a single Gateway can target routes across multiple
+namespaces. </p>
+<p>This guide assumes that you have installed Service APIs CRDs and a conformant
+controller.</p>
+<p>In the following example:</p>
 <ul>
-<li><a href="../getting-started/">Getting started</a></li>
-<li><a href="../tls/">Configuring TLS</a></li>
-<li><a href="../multiple-ns/">Routes in multiple namespaces</a></li>
+<li><code>acme-lb</code> GatewayClass: The GatewayClass responsible for satisfying Gateway
+  and Route resources.</li>
+<li><code>multi-ns-gateaway</code> Gateway: The Gateway is configured with a single listener
+  on port 80 which selects routes from <strong>all namespaces</strong> which have the label
+  <code>product: baz</code>. Notice how the <code>routes.namespaces.from</code> field in the listener
+  is set to <code>All</code>.</li>
+<li><code>service-apis-example-ns1</code> and <code>service-apis-example-ns2</code> Namespaces: These
+  are two namespaces in which we route resources are installed.</li>
+<li><code>http-app-1</code> and <code>http-app-2</code> HTTPRoutes: These are two resources that are
+  installed in separate namespaces. These routes will be picked up by
+  <code>multi-ns-gateway</code> resource for the following reasons:<ul>
+<li>Both have the <code>product: baz</code> label on them.</li>
+<li><code>http-app-1</code> HTTPRoute has <code>spec.gateways.allow</code> set to <code>All</code>.  The route
+  owner here has opted to allow <strong>all</strong> Gateways in the cluster to bind to
+  this Route.</li>
+<li><code>http-app-2</code> HTTPRoute has <code>spec.gateways.allow</code> set to <code>FromList</code> and
+  contains a reference to the <code>multi-ns-gateway</code> in <code>default</code> namespace. In
+  this case, no other Gateway can bind to this route.  explictly set this
+  field so that Gateways from other namespaces can target the route.</li>
 </ul>
+</li>
+</ul>
+<pre><code>kind: GatewayClass
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: acme-lb
+spec:
+  controller: acme.io/gateway-controller
+  parametersRef:
+    name: acme-lb
+    group: acme.io
+    kind: Parameters
+---
+kind: Gateway
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: multi-ns-gateway
+  namespace: default
+spec:
+  gatewayClassName: acme-lb
+  listeners:  # Use GatewayClass defaults for listener definition.
+  - protocol: HTTP
+    port: 80
+    routes:
+      kind: HTTPRoute
+      selector:
+        matchLabels:
+          product: baz
+      namespaces:
+        from: &quot;All&quot;
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-apis-example-ns1
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-1
+  namespace: service-apis-example-ns1
+  labels:
+    product: baz
+spec:
+  gateways:
+    allow: All
+  hostnames:
+  - &quot;foo.com&quot;
+  rules:
+  - matches:
+    - path:
+        type: Prefix
+        value: /bar
+    forwardTo:
+    - serviceName: my-foo-service1
+      port: 8080
+  - matches:
+    - headers:
+        type: Exact
+        values:
+          magic: foo
+      path:
+        type: Prefix
+        value: /some/thing
+    forwardTo:
+    - serviceName: my-foo-service2
+      port: 8080
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-apis-example-ns2
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-2
+  namespace: service-apis-example-ns2
+  labels:
+    product: baz
+spec:
+  gateways:
+    allow: FromList
+    gatewayRefs:
+    - name: multi-ns-gateway
+      namespace: default
+  hostnames:
+  - &quot;bar.com&quot;
+  rules:
+  - matches:
+    - path:
+        type: Prefix
+        value: /
+    forwardTo:
+    - serviceName: my-bar-service1
+      port: 8080
+</code></pre>
+
+<p>Please note that this guide illustrates this feature for HTTPRoute resource
+only as an example. The same can be accomplished with other route types as
+well.</p>
                 
                   
                 
@@ -501,7 +621,7 @@ Please checkout one of the following guides:</p>
     <div class="md-footer-nav">
       <nav class="md-footer-nav__inner md-grid">
         
-          <a href="../security-model/" title="Security Model" class="md-flex md-footer-nav__link md-footer-nav__link--prev" rel="prev">
+          <a href="../getting-started/" title="Getting started" class="md-flex md-footer-nav__link md-footer-nav__link--prev" rel="prev">
             <div class="md-flex__cell md-flex__cell--shrink">
               <i class="md-icon md-icon--arrow-back md-footer-nav__button"></i>
             </div>
@@ -510,19 +630,19 @@ Please checkout one of the following guides:</p>
                 <span class="md-footer-nav__direction">
                   Previous
                 </span>
-                Security Model
+                Getting started
               </span>
             </div>
           </a>
         
         
-          <a href="../getting-started/" title="Getting started" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
+          <a href="../tls/" title="TLS" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
             <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
               <span class="md-flex__ellipsis">
                 <span class="md-footer-nav__direction">
                   Next
                 </span>
-                Getting started
+                TLS
               </span>
             </div>
             <div class="md-flex__cell md-flex__cell--shrink">

--- a/docs/multiple-ns/index.html
+++ b/docs/multiple-ns/index.html
@@ -482,22 +482,23 @@ controller.</p>
 <li><code>acme-lb</code> GatewayClass: The GatewayClass responsible for satisfying Gateway
   and Route resources.</li>
 <li><code>multi-ns-gateaway</code> Gateway: The Gateway is configured with a single listener
-  on port 80 which selects routes from <strong>all namespaces</strong> which have the label
-  <code>product: baz</code>. Notice how the <code>routes.namespaces.from</code> field in the listener
-  is set to <code>All</code>.</li>
+  on port 80 which selects routes that have the label <code>product: baz</code> in any
+  namespace.  Notice how the <code>routes.namespaces.from</code> field in the listener is
+  set to <code>All</code>.</li>
 <li><code>service-apis-example-ns1</code> and <code>service-apis-example-ns2</code> Namespaces: These
-  are two namespaces in which we route resources are installed.</li>
+  are the namespaces in which route resources are instantiated.</li>
 <li><code>http-app-1</code> and <code>http-app-2</code> HTTPRoutes: These are two resources that are
-  installed in separate namespaces. These routes will be picked up by
-  <code>multi-ns-gateway</code> resource for the following reasons:<ul>
+  installed in separate namespaces. These routes will be bound to Gateway
+  <code>multi-ns-gateway</code> for the following reasons:<ul>
 <li>Both have the <code>product: baz</code> label on them.</li>
 <li><code>http-app-1</code> HTTPRoute has <code>spec.gateways.allow</code> set to <code>All</code>.  The route
-  owner here has opted to allow <strong>all</strong> Gateways in the cluster to bind to
-  this Route.</li>
+  owner has opted to allow <strong>all</strong> Gateways in the cluster to bind to this
+  Route.</li>
 <li><code>http-app-2</code> HTTPRoute has <code>spec.gateways.allow</code> set to <code>FromList</code> and
-  contains a reference to the <code>multi-ns-gateway</code> in <code>default</code> namespace. In
-  this case, no other Gateway can bind to this route.  explictly set this
-  field so that Gateways from other namespaces can target the route.</li>
+  contains a reference to the <code>multi-ns-gateway</code> in <code>default</code> namespace.
+  This means that only the specified Gateway resource can bind to this
+  route.  Additional Gateways may be added to this list to allow them to
+  bind to this route.</li>
 </ul>
 </li>
 </ul>

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -290,6 +290,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/resources/index.html
+++ b/docs/resources/index.html
@@ -384,6 +384,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/security-model/index.html
+++ b/docs/security-model/index.html
@@ -446,6 +446,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -286,6 +286,18 @@
 
 
   <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
+
+  <li class="md-nav__item">
     <a href="../tls/" title="TLS" class="md-nav__link">
       TLS
     </a>

--- a/docs/tls/index.html
+++ b/docs/tls/index.html
@@ -290,6 +290,18 @@
           
           
 
+
+  <li class="md-nav__item">
+    <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-nav__link">
+      Multiple namespaces and routes
+    </a>
+  </li>
+
+        
+          
+          
+          
+
   
 
 
@@ -981,7 +993,7 @@ or ciphers to use.</p>
     <div class="md-footer-nav">
       <nav class="md-footer-nav__inner md-grid">
         
-          <a href="../getting-started/" title="Getting started" class="md-flex md-footer-nav__link md-footer-nav__link--prev" rel="prev">
+          <a href="../multiple-ns/" title="Multiple namespaces and routes" class="md-flex md-footer-nav__link md-footer-nav__link--prev" rel="prev">
             <div class="md-flex__cell md-flex__cell--shrink">
               <i class="md-icon md-icon--arrow-back md-footer-nav__button"></i>
             </div>
@@ -990,7 +1002,7 @@ or ciphers to use.</p>
                 <span class="md-footer-nav__direction">
                   Previous
                 </span>
-                Getting started
+                Multiple namespaces and routes
               </span>
             </div>
           </a>

--- a/examples/routes-in-multiple-namespaces.yaml
+++ b/examples/routes-in-multiple-namespaces.yaml
@@ -12,7 +12,8 @@ spec:
 kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
-  name: my-gateway
+  name: multi-ns-gateway
+  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
@@ -22,17 +23,25 @@ spec:
       kind: HTTPRoute
       selector:
         matchLabels:
-          app: foo
+          product: baz
       namespaces:
-        from: "Same"
+        from: "All"
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-apis-example-ns1
 ---
 kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: http-app-1
+  namespace: service-apis-example-ns1
   labels:
-    app: foo
+    product: baz
 spec:
+  gateways:
+    allow: All
   hostnames:
   - "foo.com"
   rules:
@@ -41,7 +50,7 @@ spec:
         type: Prefix
         value: /bar
     forwardTo:
-    - serviceName: my-service1
+    - serviceName: my-foo-service1
       port: 8080
   - matches:
     - headers:
@@ -52,5 +61,34 @@ spec:
         type: Prefix
         value: /some/thing
     forwardTo:
-    - serviceName: my-service2
+    - serviceName: my-foo-service2
+      port: 8080
+---
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: service-apis-example-ns2
+---
+kind: HTTPRoute
+apiVersion: networking.x-k8s.io/v1alpha1
+metadata:
+  name: http-app-2
+  namespace: service-apis-example-ns2
+  labels:
+    product: baz
+spec:
+  gateways:
+    allow: FromList
+    gatewayRefs:
+    - name: multi-ns-gateway
+      namespace: default
+  hostnames:
+  - "bar.com"
+  rules:
+  - matches:
+    - path:
+        type: Prefix
+        value: /
+    forwardTo:
+    - serviceName: my-bar-service1
       port: 8080

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
   - Guides:
     - Introduction: guides.md
     - Getting started: getting-started.md
+    - Multiple namespaces and routes: multiple-ns.md
     - TLS: tls.md
   - References:
     - API specification: spec.md


### PR DESCRIPTION
A guide which illustrates how routes from multiple namespaces are targeted by a single Gateway resource.

See #333