### PR TITLE
Adding sig-network leads and service-apis maintainers as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# See the OWNERS_ALIASES file at https://github.com/kubernetes-sigs/service-apis/blob/master/OWNERS_ALIASES for a list of members for each alias. 
 
 approvers:
   - bowei
-  - robscott
+  - sig-network-leads
+  - service-apis-admins
+  - service-apis-maintainers
 
 reviewers:
-  - bowei
-  - robscott
-  - hbagdi
-  - jpeach
-  - danehans
+  - service-apis-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,22 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# This file should be kept in sync with k/org.
+
+aliases:
+  # Reference: https://github.com/kubernetes/org/blob/master/OWNERS_ALIASES
+  sig-network-leads:
+    - caseydavenport
+    - dcbw
+    - thockin
+
+  # Reference: https://github.com/kubernetes/org/blob/master/config/kubernetes-sigs/sig-network/teams.yaml
+  service-apis-admins:
+    - bowei
+    - thockin
+
+  service-apis-maintainers:
+    - bowei
+    - danehans
+    - hbagdi
+    - jpeach
+    - robscott
+    - thockin


### PR DESCRIPTION
This mirrors the [structure that cluster-api uses](https://github.com/kubernetes-sigs/cluster-api/blob/master/OWNERS). I've left Bowei in temporarily just in case all these aliases don't end up working as expected.

/cc @danehans @hbagdi @jpeach 
/assign @bowei 