### PR TITLE
Adding a PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,52 @@
+<!--  Thanks for sending a pull request! Here are some tips for you:
+
+1. If this is your first time contributing to Service APIs, please read our
+   developer guide (https://kubernetes-sigs.github.io/service-apis/devguide/)
+   and our community page (https://kubernetes-sigs.github.io/service-apis/community/).
+2. If this is your first time contributing to a Kubernetes project, please read
+   our contributor guidelines:
+   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
+3. Please label this pull request according to what type of issue you are
+   addressing, especially if this is a release targeted pull request. For
+   reference on required PR/issue labels, read here:
+   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+4. If you want *faster* PR reviews, read how:
+   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+5. If the PR is unfinished, see how to mark it:
+   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+-->
+
+**What type of PR is this?**
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+<!--
+*Automatically closes linked issue when PR is merged.
+Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
+-->
+Fixes #
+
+**Does this PR introduce a user-facing change?**:
+<!--
+If no, just write "NONE" in the release-note block below.
+If yes, please enter a release note below:
+-->
+```release-note
+
+```


### PR DESCRIPTION
This is mostly a copy of the [Kubernetes PR template](https://github.com/kubernetes/kubernetes/blob/master/.github/PULL_REQUEST_TEMPLATE.md) with some of the less relevant bits removed. All I really wanted was some kind of release note automation, so if the rest of this feels like it adds too much overhead, I'm fine with simplifying this.