### PR TITLE
Fixing bad link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Participation in the Kubernetes community is governed by the
 [slack]: https://kubernetes.slack.com/messages/sig-network-service-apis
 [guides]: https://kubernetes-sigs.github.io/service-apis/guides
 [spec]: https://kubernetes-sigs.github.io/service-apis/spec
-[concepts]: https://kubernetes-sigs.github.io/service-apis/concepts
+[concepts]: https://kubernetes-sigs.github.io/service-apis/api-overview
 [security-model]: https://kubernetes-sigs.github.io/service-apis/security-model
 

--- a/docs-src/api-overview.md
+++ b/docs-src/api-overview.md
@@ -45,7 +45,7 @@ In Ingress v1beta1, the closest analog to GatewayClass is the `ingress-class` an
 
 A Gateway describes how traffic can be translated to Services within the cluster.
 That is, it defines a request for a way to translate traffic from somewhere that does not know about Kubernetes to somewhere that does.
-For example, traffic sent to a Kubernetes Services by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
+For example, traffic sent to a Kubernetes Service by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
 While many use cases have client traffic originating “outside” the cluster, this is not a requirement.
 
 It defines a request for a specific load balancer config that implements the GatewayClass’ configuration and behaviour contract.
@@ -125,7 +125,7 @@ Here is a summary of extension points in the API:
 - **XForwardTo.BackendRef**: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.
-- **HTTPRouteFilter**: This API type in HTTPoute provides a way to hook into the
+- **HTTPRouteFilter**: This API type in HTTPRoute provides a way to hook into the
   request/response lifecycle of an HTTP request.
 - **Custom Routes**: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols

--- a/docs-src/security-model.md
+++ b/docs-src/security-model.md
@@ -111,8 +111,8 @@ To be considered conformant with the Service APIs spec, controllers need to:
 * Populate status fields on Gateways and Resources to indicate if they are
   compatible with the corresponding GatewayClass configuration.
 * Ensure that all Routes added to a Gateway:
-  * Have been selected by the Gateway.
-  * Have a Gateways field that allows the Gateway use of the route.
+    * Have been selected by the Gateway.
+    * Have a Gateways field that allows the Gateway use of the route.
 
 ## Alternative Approaches Considered
 ### New API Resources

--- a/docs/api-overview/index.html
+++ b/docs/api-overview/index.html
@@ -760,7 +760,7 @@ In Ingress v1beta1, the closest analog to GatewayClass is the <code>ingress-clas
 <h3 id="gateway">Gateway</h3>
 <p>A Gateway describes how traffic can be translated to Services within the cluster.
 That is, it defines a request for a way to translate traffic from somewhere that does not know about Kubernetes to somewhere that does.
-For example, traffic sent to a Kubernetes Services by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
+For example, traffic sent to a Kubernetes Service by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
 While many use cases have client traffic originating “outside” the cluster, this is not a requirement.</p>
 <p>It defines a request for a specific load balancer config that implements the GatewayClass’ configuration and behaviour contract.
 The resource MAY be created by an operator directly, or MAY be created by a controller handling a GatewayClass.</p>
@@ -821,7 +821,7 @@ purpose API.</p>
 <li><strong>XForwardTo.BackendRef</strong>: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.</li>
-<li><strong>HTTPRouteFilter</strong>: This API type in HTTPoute provides a way to hook into the
+<li><strong>HTTPRouteFilter</strong>: This API type in HTTPRoute provides a way to hook into the
   request/response lifecycle of an HTTP request.</li>
 <li><strong>Custom Routes</strong>: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols

--- a/docs/security-model/index.html
+++ b/docs/security-model/index.html
@@ -976,9 +976,11 @@ selection by Gateways in the same namespace. </p>
 <ul>
 <li>Populate status fields on Gateways and Resources to indicate if they are
   compatible with the corresponding GatewayClass configuration.</li>
-<li>Ensure that all Routes added to a Gateway:</li>
+<li>Ensure that all Routes added to a Gateway:<ul>
 <li>Have been selected by the Gateway.</li>
 <li>Have a Gateways field that allows the Gateway use of the route.</li>
+</ul>
+</li>
 </ul>
 <h2 id="alternative-approaches-considered">Alternative Approaches Considered</h2>
 <h3 id="new-api-resources">New API Resources</h3>


### PR DESCRIPTION
https://kubernetes-sigs.github.io/service-apis/concepts renders as `404 - Not found`

"api-overview" is the first section in Concepts, so I assume it was intended to link here instead