### PR TITLE
Replace obsolete status ConditionInvalidRoutes with InvalidRoutesRef

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -418,8 +418,8 @@ type RouteBindingSelector struct {
 	// application protocol specified in the Listener's Protocol field.
 	//
 	// If an implementation does not support or recognize this
-	// resource type, it SHOULD raise a "ConditionInvalidRoutes"
-	// condition for the affected Listener.
+	// resource type, it SHOULD set the "ResolvedRefs" condition to false for
+	// this listener with the "InvalidRoutesRef" reason.
 	//
 	// Support: Core
 	Kind string `json:"kind"`
@@ -776,7 +776,7 @@ const (
 	ListenerReasonInvalidCertificateRef ListenerConditionReason = "InvalidCertificateRef"
 
 	// ListenerReasonInvalidRoutesRef is used when the Listener's Routes
-	// selector is invalid or cannot be resolved. Note that it is not
+	// selector or kind is invalid or cannot be resolved. Note that it is not
 	// an error for this selector to not resolve any Routes, and the
 	// "ResolvedRefs" status condition should not be raised in that case.
 	ListenerReasonInvalidRoutesRef ListenerConditionReason = "InvalidRoutesRef"

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -94,7 +94,7 @@ spec:
                           minLength: 1
                           type: string
                         kind:
-                          description: "Kind is the kind of the route resource to select. \n Kind MUST correspond to kinds of routes that are compatible with the application protocol specified in the Listener's Protocol field. \n If an implementation does not support or recognize this resource type, it SHOULD raise a \"ConditionInvalidRoutes\" condition for the affected Listener. \n Support: Core"
+                          description: "Kind is the kind of the route resource to select. \n Kind MUST correspond to kinds of routes that are compatible with the application protocol specified in the Listener's Protocol field. \n If an implementation does not support or recognize this resource type, it SHOULD set the \"ResolvedRefs\" condition to false for this listener with the \"InvalidRoutesRef\" reason. \n Support: Core"
                           type: string
                         namespaces:
                           default:

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -2899,8 +2899,8 @@ string
 <p>Kind MUST correspond to kinds of routes that are compatible with the
 application protocol specified in the Listener&rsquo;s Protocol field.</p>
 <p>If an implementation does not support or recognize this
-resource type, it SHOULD raise a &ldquo;ConditionInvalidRoutes&rdquo;
-condition for the affected Listener.</p>
+resource type, it SHOULD set the &ldquo;ResolvedRefs&rdquo; condition to false for
+this listener with the &ldquo;InvalidRoutesRef&rdquo; reason.</p>
 <p>Support: Core</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -3430,8 +3430,8 @@ string
 <p>Kind MUST correspond to kinds of routes that are compatible with the
 application protocol specified in the Listener&rsquo;s Protocol field.</p>
 <p>If an implementation does not support or recognize this
-resource type, it SHOULD raise a &ldquo;ConditionInvalidRoutes&rdquo;
-condition for the affected Listener.</p>
+resource type, it SHOULD set the &ldquo;ResolvedRefs&rdquo; condition to false for
+this listener with the &ldquo;InvalidRoutesRef&rdquo; reason.</p>
 <p>Support: Core</p>
 </td>
 </tr>


### PR DESCRIPTION
`ConditionInvalidRoutes` was obsoleted by b1cc891fe01d51f07833f7a0595ac012bb8d8c56.

Hence this patch replaces `ConditionInvalidRoutes` with `InvalidRoutesRef`.
