### PR TITLE
Update RouteSelector to Selector in Gateway

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -384,9 +384,9 @@ type RouteBindingSelector struct {
 	// +kubebuilder:default={from: "Same"}
 	Namespaces *RouteNamespaces `json:"namespaces,omitempty"`
 	// Selector specifies a set of route labels used for selecting
-	// routes to associate with the Gateway. If RouteSelector is defined,
-	// only routes matching the RouteSelector are associated with the Gateway.
-	// An empty RouteSelector matches all routes.
+	// routes to associate with the Gateway. If this Selector is defined,
+	// only routes matching the Selector are associated with the Gateway.
+	// An empty Selector matches all routes.
 	//
 	// Support: Core
 	//

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -140,7 +140,7 @@ spec:
                               type: object
                           type: object
                         selector:
-                          description: "Selector specifies a set of route labels used for selecting routes to associate with the Gateway. If RouteSelector is defined, only routes matching the RouteSelector are associated with the Gateway. An empty RouteSelector matches all routes. \n Support: Core"
+                          description: "Selector specifies a set of route labels used for selecting routes to associate with the Gateway. If this Selector is defined, only routes matching the Selector are associated with the Gateway. An empty Selector matches all routes. \n Support: Core"
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector requirements. The requirements are ANDed.

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -2860,9 +2860,9 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <em>(Optional)</em>
 <p>Selector specifies a set of route labels used for selecting
-routes to associate with the Gateway. If RouteSelector is defined,
-only routes matching the RouteSelector are associated with the Gateway.
-An empty RouteSelector matches all routes.</p>
+routes to associate with the Gateway. If this Selector is defined,
+only routes matching the Selector are associated with the Gateway.
+An empty Selector matches all routes.</p>
 <p>Support: Core</p>
 </td>
 </tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -3391,9 +3391,9 @@ Kubernetes meta/v1.LabelSelector
 <td>
 <em>(Optional)</em>
 <p>Selector specifies a set of route labels used for selecting
-routes to associate with the Gateway. If RouteSelector is defined,
-only routes matching the RouteSelector are associated with the Gateway.
-An empty RouteSelector matches all routes.</p>
+routes to associate with the Gateway. If this Selector is defined,
+only routes matching the Selector are associated with the Gateway.
+An empty Selector matches all routes.</p>
 <p>Support: Core</p>
 </td>
 </tr>


### PR DESCRIPTION
30ca50d3f43d1760d45ee8ab3843e7b164141577 renamed `RouteSelector` to `Selector`.

Hence this patch fixes the `RouteSelector` in docs/comments.
