### PR TITLE
Increasing max length of ForwardTo from 4 to 16

### DIFF
--- a/apis/v1alpha1/httproute_types.go
+++ b/apis/v1alpha1/httproute_types.go
@@ -202,7 +202,7 @@ type HTTPRouteRule struct {
 	// error code is returned.
 	//
 	// +optional
-	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:MaxItems=16
 	ForwardTo []HTTPRouteForwardTo `json:"forwardTo,omitempty"`
 }
 

--- a/apis/v1alpha1/tcproute_types.go
+++ b/apis/v1alpha1/tcproute_types.go
@@ -68,7 +68,7 @@ type TCPRouteRule struct {
 	// be sent.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:MaxItems=16
 	ForwardTo []RouteForwardTo `json:"forwardTo"`
 }
 

--- a/apis/v1alpha1/tlsroute_types.go
+++ b/apis/v1alpha1/tlsroute_types.go
@@ -72,7 +72,7 @@ type TLSRouteRule struct {
 	// sent.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:MaxItems=16
 	ForwardTo []RouteForwardTo `json:"forwardTo"`
 }
 

--- a/apis/v1alpha1/udproute_types.go
+++ b/apis/v1alpha1/udproute_types.go
@@ -67,7 +67,7 @@ type UDPRouteRule struct {
 	// be sent.
 	//
 	// +kubebuilder:validation:MinItems=1
-	// +kubebuilder:validation:MaxItems=4
+	// +kubebuilder:validation:MaxItems=16
 	ForwardTo []RouteForwardTo `json:"forwardTo"`
 }
 

--- a/config/crd/bases/networking.x-k8s.io_httproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_httproutes.yaml
@@ -320,7 +320,7 @@ spec:
                         required:
                         - port
                         type: object
-                      maxItems: 4
+                      maxItems: 16
                       type: array
                     matches:
                       default:

--- a/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tcproutes.yaml
@@ -119,7 +119,7 @@ spec:
                         required:
                         - port
                         type: object
-                      maxItems: 4
+                      maxItems: 16
                       minItems: 1
                       type: array
                     matches:

--- a/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_tlsroutes.yaml
@@ -119,7 +119,7 @@ spec:
                         required:
                         - port
                         type: object
-                      maxItems: 4
+                      maxItems: 16
                       minItems: 1
                       type: array
                     matches:

--- a/config/crd/bases/networking.x-k8s.io_udproutes.yaml
+++ b/config/crd/bases/networking.x-k8s.io_udproutes.yaml
@@ -119,7 +119,7 @@ spec:
                         required:
                         - port
                         type: object
-                      maxItems: 4
+                      maxItems: 16
                       minItems: 1
                       type: array
                     matches:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As identified in #481, the initial validation on the length of ForwardTo was too restrictive. Knative has some compelling use cases for 10+ ForwardTo statements. [Further discussion](https://knative.slack.com/archives/C93E33SN8/p1606886097119400) showed that 16 would be a reasonable upper limit for them. I've also taken some time to ensure that this would also be possible for common proxies such as nginx, haproxy, and envoy. The primary reason for an upper limit here is to ensure we have no unbounded lists in our API. Increasing this limit does not appear to be an issue for any implementations I'm aware of. If it is, please let me know.

**Which issue(s) this PR fixes**:
Fixes #481 

**Does this PR introduce a user-facing change?**:
```release-note
ForwardTo max length has been increased from 4 to 16.
```

/cc @danehans @hbagdi 