### PR TITLE
Fix broken doc link

### DIFF
--- a/docs-src/faq.md
+++ b/docs-src/faq.md
@@ -53,7 +53,7 @@
       a proud tradition of extending Ingress objects.
 
     * Use API-defined extension points. Some Service
-      API objects have explicit [extension points](/concepts/#extension-points)
+      API objects have explicit [extension points](/api-overview/#extension-points)
       for implementations to use.
 
 *  **Q: Where can I find Service API releases?<br>**

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -604,7 +604,7 @@ an example of using explicit object references.</p>
 </li>
 <li>
 <p>Use API-defined extension points. Some Service
-  API objects have explicit <a href="/concepts/#extension-points">extension points</a>
+  API objects have explicit <a href="/api-overview/#extension-points">extension points</a>
   for implementations to use.</p>
 </li>
 </ul>


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Looks like there was a big doc change and this link wasn't updated.
