### PR TITLE
examples: Remove namespace from examples

### DIFF
--- a/docs/multiple-ns/index.html
+++ b/docs/multiple-ns/index.html
@@ -601,7 +601,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: multi-ns-gateway
-  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.

--- a/examples/basic-tcp.yaml
+++ b/examples/basic-tcp.yaml
@@ -13,7 +13,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: my-gateway
-  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
@@ -31,7 +30,6 @@ kind: TCPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: tcp-app-1
-  namespace: default
   labels:
     app: foo
 spec:

--- a/examples/basic-udp.yaml
+++ b/examples/basic-udp.yaml
@@ -13,7 +13,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: my-gateway
-  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.
@@ -31,7 +30,6 @@ kind: UDPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: udp-app-1
-  namespace: default
   labels:
     app: foo
 spec:

--- a/examples/default-match-http.yaml
+++ b/examples/default-match-http.yaml
@@ -11,7 +11,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: default-match-gw
-  namespace: default
 spec:
   gatewayClassName: default-match-example
   listeners:
@@ -35,7 +34,6 @@ kind: HTTPRoute
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: default-match-route
-  namespace: default
   labels:
     app: default-match
 spec:

--- a/examples/multiple-tcp.yaml
+++ b/examples/multiple-tcp.yaml
@@ -2,7 +2,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: gateway
-  namespace: default
 spec:
   gatewayClassName: default-class
   addresses:

--- a/examples/routes-in-multiple-namespaces.yaml
+++ b/examples/routes-in-multiple-namespaces.yaml
@@ -13,7 +13,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: multi-ns-gateway
-  namespace: default
 spec:
   gatewayClassName: acme-lb
   listeners:  # Use GatewayClass defaults for listener definition.

--- a/examples/single-http.yaml
+++ b/examples/single-http.yaml
@@ -2,7 +2,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: gateway
-  namespace: default
 spec:
   gatewayClassName: default-class
   addresses:

--- a/examples/wildcard-http.yaml
+++ b/examples/wildcard-http.yaml
@@ -2,7 +2,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: gateway
-  namespace: default
 spec:
   gatewayClassName: default-class
   addresses:

--- a/examples/wildcard-https.yaml
+++ b/examples/wildcard-https.yaml
@@ -2,7 +2,6 @@ kind: Gateway
 apiVersion: networking.x-k8s.io/v1alpha1
 metadata:
   name: gateway
-  namespace: default
 spec:
   gatewayClassName: default-class
   addresses:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes any default namespace specified on resources so that users can deploy into any namespace other than "default".

**Which issue(s) this PR fixes**:
Fixes #498

Signed-off-by: Steve Sloka <slokas@vmware.com>
