### PR TITLE
Cleaning up links to meeting notes and recordings

### DIFF
--- a/docs-src/community.md
+++ b/docs-src/community.md
@@ -34,39 +34,33 @@ Service APIs meetings as well as any other SIG-Network meetings.
 
 * Wednesday 11am Pacific (7pm UTC) <a target="_blank" href="https://zoom.us/j/441530404">[Zoom Link]</a> <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MjUxOHEzdXNpZWwxYmRmYXFidGltbWU1dWFfMjAyMDEyMDJUMTkwMDAwWiA4OGZlMWwzcWZuMmI2cjExazh1bTVhbTc2Y0Bn&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com&scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a>
 
-### Meeting notes
+### Meeting Notes and Recordings
 
-Meeting agendas and notes are recorded in the [meeting notes doc][meeting-notes].
+Meeting agendas and notes are maintained in the [meeting notes
+doc][meeting-notes]. Feel free to add topics for discussion at an upcoming
+meeting.
 
-All meetings are recorded and automatically uploaded to youtube:
-[Meeting recordings](https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb).
+All meetings are recorded and automatically uploaded to the [Kubernetes
+SIG-NETWORK playlist on YouTube][sig-net-yt-playlist].
 
-Some initial recordings of this working group were done manually and can be
-found in the below table:
+#### Early Meetings
+Some early community meetings were uploaded to a [separate YouTube
+playlist][early-yt-playlist].
 
-| Date               |                                |
-|--------------------|--------------------------------|
-| Future meetings    | Check the calendar             |
-| February 27, 2019  | [meeting notes][meeting-notes], [recording](https://youtu.be/QoInpFSTQbQ)   |
-| February 20, 2019  | [meeting notes][meeting-notes], [recording](https://youtu.be/i_oDQuPEhd8)   |
-| February 13, 2019  | [meeting notes][meeting-notes], [recording](https://youtu.be/bdFLubKi9_0)   |
-| February 6, 2019   | [meeting notes][meeting-notes], [recording](https://youtu.be/XvpCFaTrtBA)   |
-| January 30, 2019   | [meeting notes][meeting-notes], [recording](https://youtu.be/cTTqIR3muGk)   |
-| January 23, 2019   | [meeting notes][meeting-notes], recording TODO |
-| January 16, 2019   | [meeting notes][meeting-notes], [recording](https://youtu.be/ydA-epcZJQo)   |
-| January 9, 2019    | [meeting notes][meeting-notes], [recording](https://youtu.be/C3zO67lXGrg)   |
-| January 2, 2020    | [meeting notes][meeting-notes], recording didn't work :-( look at the notes |
-| December 19, 2019  | [meeting notes][meeting-notes], [recording](https://youtu.be/FIcySpPkGa4)   |
-| November, 2019     | [Kubecon 2019 San Diego: API evolution design discussion][kubecon-2019-na-design-discussion] |
-| November, 2019     | [SIG-NETWORK: Ingress Evolution Sync][sig-net-2019-11-sync] |
-| May, 2019          | [Kubecon 2019 Barcelona: SIG-NETWORK discussion (general topics, includes V2)][kubecon-2019-eu-discussion] |
+#### Initial Design Discussions
 
+* [Kubecon 2019 San Diego: API evolution design discussion][kubecon-2019-na-design-discussion]
+* [SIG-NETWORK: Ingress Evolution Sync][sig-net-2019-11-sync]
+* [Kubecon 2019 Barcelona: SIG-NETWORK discussion (general topics, includes V2)][kubecon-2019-eu-discussion]
+
+[sig-net-yt-playlist]: https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb
+[early-yt-playlist]: https://www.youtube.com/playlist?list=PL7KjrPTDcs4Xe6SZj-51WvBfufKf-la1O
 [kubecon-2019-na-design-discussion]: https://docs.google.com/document/d/1l_SsVPLMBZ7lm_T4u7ZDBceTTUY71-iEQUPWeOdTAxM/preview
 [kubecon-2019-eu-discussion]: https://docs.google.com/document/d/1n8AaDiPXyZHTosm1dscWhzpbcZklP3vd11fA6L6ajlY/preview
 [sig-net-2019-11-sync]: https://docs.google.com/document/d/1AqBaxNX0uS0fb_fSpVL9c8TmaSP7RYkWO8U_SdJH67k/preview
 [meeting-notes]: https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit
 
-## Presentations, Talks
+## Presentations and Talks
 
 | Date           | Title |    |
 |----------------|-------|----|

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -557,9 +557,29 @@
       <ul class="md-nav__list">
         
           <li class="md-nav__item">
-  <a href="#meeting-notes" class="md-nav__link">
-    Meeting notes
+  <a href="#meeting-notes-and-recordings" class="md-nav__link">
+    Meeting Notes and Recordings
   </a>
+  
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+        
+          <li class="md-nav__item">
+  <a href="#early-meetings" class="md-nav__link">
+    Early Meetings
+  </a>
+  
+</li>
+        
+          <li class="md-nav__item">
+  <a href="#initial-design-discussions" class="md-nav__link">
+    Initial Design Discussions
+  </a>
+  
+</li>
+        
+      </ul>
+    </nav>
   
 </li>
         
@@ -569,8 +589,8 @@
 </li>
       
         <li class="md-nav__item">
-  <a href="#presentations-talks" class="md-nav__link">
-    Presentations, Talks
+  <a href="#presentations-and-talks" class="md-nav__link">
+    Presentations and Talks
   </a>
   
 </li>
@@ -653,9 +673,29 @@
       <ul class="md-nav__list">
         
           <li class="md-nav__item">
-  <a href="#meeting-notes" class="md-nav__link">
-    Meeting notes
+  <a href="#meeting-notes-and-recordings" class="md-nav__link">
+    Meeting Notes and Recordings
   </a>
+  
+    <nav class="md-nav">
+      <ul class="md-nav__list">
+        
+          <li class="md-nav__item">
+  <a href="#early-meetings" class="md-nav__link">
+    Early Meetings
+  </a>
+  
+</li>
+        
+          <li class="md-nav__item">
+  <a href="#initial-design-discussions" class="md-nav__link">
+    Initial Design Discussions
+  </a>
+  
+</li>
+        
+      </ul>
+    </nav>
   
 </li>
         
@@ -665,8 +705,8 @@
 </li>
       
         <li class="md-nav__item">
-  <a href="#presentations-talks" class="md-nav__link">
-    Presentations, Talks
+  <a href="#presentations-and-talks" class="md-nav__link">
+    Presentations and Talks
   </a>
   
 </li>
@@ -717,79 +757,22 @@ Service APIs meetings as well as any other SIG-Network meetings.</p>
 <ul>
 <li>Wednesday 11am Pacific (7pm UTC) <a target="_blank" href="https://zoom.us/j/441530404">[Zoom Link]</a> <a target="_blank" href="https://calendar.google.com/event?action=TEMPLATE&tmeid=MjUxOHEzdXNpZWwxYmRmYXFidGltbWU1dWFfMjAyMDEyMDJUMTkwMDAwWiA4OGZlMWwzcWZuMmI2cjExazh1bTVhbTc2Y0Bn&tmsrc=88fe1l3qfn2b6r11k8um5am76c%40group.calendar.google.com&scp=ALL"><img border="0" src="https://www.google.com/calendar/images/ext/gc_button1_en.gif"></a></li>
 </ul>
-<h3 id="meeting-notes">Meeting notes</h3>
-<p>Meeting agendas and notes are recorded in the <a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes doc</a>.</p>
-<p>All meetings are recorded and automatically uploaded to youtube:
-<a href="https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb">Meeting recordings</a>.</p>
-<p>Some initial recordings of this working group were done manually and can be
-found in the below table:</p>
-<table>
-<thead>
-<tr>
-<th>Date</th>
-<th></th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Future meetings</td>
-<td>Check the calendar</td>
-</tr>
-<tr>
-<td>February 27, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/QoInpFSTQbQ">recording</a></td>
-</tr>
-<tr>
-<td>February 20, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/i_oDQuPEhd8">recording</a></td>
-</tr>
-<tr>
-<td>February 13, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/bdFLubKi9_0">recording</a></td>
-</tr>
-<tr>
-<td>February 6, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/XvpCFaTrtBA">recording</a></td>
-</tr>
-<tr>
-<td>January 30, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/cTTqIR3muGk">recording</a></td>
-</tr>
-<tr>
-<td>January 23, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, recording TODO</td>
-</tr>
-<tr>
-<td>January 16, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/ydA-epcZJQo">recording</a></td>
-</tr>
-<tr>
-<td>January 9, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/C3zO67lXGrg">recording</a></td>
-</tr>
-<tr>
-<td>January 2, 2020</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, recording didn't work :-( look at the notes</td>
-</tr>
-<tr>
-<td>December 19, 2019</td>
-<td><a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes</a>, <a href="https://youtu.be/FIcySpPkGa4">recording</a></td>
-</tr>
-<tr>
-<td>November, 2019</td>
-<td><a href="https://docs.google.com/document/d/1l_SsVPLMBZ7lm_T4u7ZDBceTTUY71-iEQUPWeOdTAxM/preview">Kubecon 2019 San Diego: API evolution design discussion</a></td>
-</tr>
-<tr>
-<td>November, 2019</td>
-<td><a href="https://docs.google.com/document/d/1AqBaxNX0uS0fb_fSpVL9c8TmaSP7RYkWO8U_SdJH67k/preview">SIG-NETWORK: Ingress Evolution Sync</a></td>
-</tr>
-<tr>
-<td>May, 2019</td>
-<td><a href="https://docs.google.com/document/d/1n8AaDiPXyZHTosm1dscWhzpbcZklP3vd11fA6L6ajlY/preview">Kubecon 2019 Barcelona: SIG-NETWORK discussion (general topics, includes V2)</a></td>
-</tr>
-</tbody>
-</table>
-<h2 id="presentations-talks">Presentations, Talks</h2>
+<h3 id="meeting-notes-and-recordings">Meeting Notes and Recordings</h3>
+<p>Meeting agendas and notes are maintained in the <a href="https://docs.google.com/document/d/1eg-YjOHaQ7UD28htdNxBR3zufebozXKyI28cl2E11tU/edit">meeting notes
+doc</a>. Feel free to add topics for discussion at an upcoming
+meeting.</p>
+<p>All meetings are recorded and automatically uploaded to the <a href="https://www.youtube.com/playlist?list=PL69nYSiGNLP2E8vmnqo5MwPOY25sDWIxb">Kubernetes
+SIG-NETWORK playlist on YouTube</a>.</p>
+<h4 id="early-meetings">Early Meetings</h4>
+<p>Some early community meetings were uploaded to a <a href="https://www.youtube.com/playlist?list=PL7KjrPTDcs4Xe6SZj-51WvBfufKf-la1O">separate YouTube
+playlist</a>.</p>
+<h4 id="initial-design-discussions">Initial Design Discussions</h4>
+<ul>
+<li><a href="https://docs.google.com/document/d/1l_SsVPLMBZ7lm_T4u7ZDBceTTUY71-iEQUPWeOdTAxM/preview">Kubecon 2019 San Diego: API evolution design discussion</a></li>
+<li><a href="https://docs.google.com/document/d/1AqBaxNX0uS0fb_fSpVL9c8TmaSP7RYkWO8U_SdJH67k/preview">SIG-NETWORK: Ingress Evolution Sync</a></li>
+<li><a href="https://docs.google.com/document/d/1n8AaDiPXyZHTosm1dscWhzpbcZklP3vd11fA6L6ajlY/preview">Kubecon 2019 Barcelona: SIG-NETWORK discussion (general topics, includes V2)</a></li>
+</ul>
+<h2 id="presentations-and-talks">Presentations and Talks</h2>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Previously the links to older community meetings were more prominent than our current meeting notes and recordings. This should fix that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
