### PR TITLE
Fixes TLS Mode Defaulting

### DIFF
--- a/apis/v1alpha1/gateway_types.go
+++ b/apis/v1alpha1/gateway_types.go
@@ -310,21 +310,30 @@ type GatewayTLSConfig struct {
 	// Mode defines the TLS behavior for the TLS session initiated by the client.
 	// There are two possible modes:
 	// - Terminate: The TLS session between the downstream client
-	//   and the Gateway is terminated at the Gateway.
+	//   and the Gateway is terminated at the Gateway. This mode requires
+	//   certificateRef to be set.
 	// - Passthrough: The TLS session is NOT terminated by the Gateway. This
 	//   implies that the Gateway can't decipher the TLS stream except for
 	//   the ClientHello message of the TLS protocol.
 	//   CertificateRef field is ignored in this mode.
+	//
+	// Support: Core
+	//
+	// +kubebuilder:default=Terminate
 	Mode TLSModeType `json:"mode,omitempty"`
 
-	// CertificateRef is the reference to Kubernetes object that
-	// contain a TLS certificate and private key.
-	// This certificate MUST be used for TLS handshakes for the domain
-	// this GatewayTLSConfig is associated with.
-	// If an entry in this list omits or specifies the empty
-	// string for both the group and the resource, the resource defaults to "secrets".
-	// An implementation may support other resources (for example, resource
+	// CertificateRef is the reference to Kubernetes object that contain a
+	// TLS certificate and private key. This certificate MUST be used for
+	// TLS handshakes for the domain this GatewayTLSConfig is associated with.
+	//
+	// This field is required when mode is set to "Terminate" (default) and
+	// optional otherwise.
+	//
+	// If an entry in this list omits or specifies the empty string for both
+	// the group and the resource, the resource defaults to "secrets". An
+	// implementation may support other resources (for example, resource
 	// "mycertificates" in group "networking.acme.io").
+	//
 	// Support: Core (Kubernetes Secrets)
 	// Support: Implementation-specific (Other resource types)
 	//
@@ -337,6 +346,8 @@ type GatewayTLSConfig struct {
 	// CertificateRef must be defined even if `routeOverride.certificate` is
 	// set to 'Allow' as it will be used as the default certificate for the
 	// listener.
+	//
+	// Support: Core
 	//
 	// +kubebuilder:default={certificate:Deny}
 	RouteOverride TLSOverridePolicy `json:"routeOverride,omitempty"`
@@ -357,7 +368,6 @@ type GatewayTLSConfig struct {
 
 // TLSModeType type defines behavior of gateway with TLS protocol.
 // +kubebuilder:validation:Enum=Terminate;Passthrough
-// +kubebuilder:default=Terminate
 type TLSModeType string
 
 const (

--- a/config/crd/bases/networking.x-k8s.io_gateways.yaml
+++ b/config/crd/bases/networking.x-k8s.io_gateways.yaml
@@ -176,7 +176,7 @@ spec:
                       description: "TLS is the TLS configuration for the Listener. This field is required if the Protocol field is \"HTTPS\" or \"TLS\" and ignored otherwise. \n The association of SNIs to Certificate defined in GatewayTLSConfig is defined based on the Hostname field for this listener. \n The GatewayClass MUST use the longest matching SNI out of all available certificates for any TLS handshake. \n Support: Core"
                       properties:
                         certificateRef:
-                          description: 'CertificateRef is the reference to Kubernetes object that contain a TLS certificate and private key. This certificate MUST be used for TLS handshakes for the domain this GatewayTLSConfig is associated with. If an entry in this list omits or specifies the empty string for both the group and the resource, the resource defaults to "secrets". An implementation may support other resources (for example, resource "mycertificates" in group "networking.acme.io"). Support: Core (Kubernetes Secrets) Support: Implementation-specific (Other resource types)'
+                          description: "CertificateRef is the reference to Kubernetes object that contain a TLS certificate and private key. This certificate MUST be used for TLS handshakes for the domain this GatewayTLSConfig is associated with. \n This field is required when mode is set to \"Terminate\" (default) and optional otherwise. \n If an entry in this list omits or specifies the empty string for both the group and the resource, the resource defaults to \"secrets\". An implementation may support other resources (for example, resource \"mycertificates\" in group \"networking.acme.io\"). \n Support: Core (Kubernetes Secrets) Support: Implementation-specific (Other resource types)"
                           properties:
                             group:
                               description: Group is the group of the referent.
@@ -199,7 +199,8 @@ spec:
                           - name
                           type: object
                         mode:
-                          description: 'Mode defines the TLS behavior for the TLS session initiated by the client. There are two possible modes: - Terminate: The TLS session between the downstream client   and the Gateway is terminated at the Gateway. - Passthrough: The TLS session is NOT terminated by the Gateway. This   implies that the Gateway can''t decipher the TLS stream except for   the ClientHello message of the TLS protocol.   CertificateRef field is ignored in this mode.'
+                          default: Terminate
+                          description: "Mode defines the TLS behavior for the TLS session initiated by the client. There are two possible modes: - Terminate: The TLS session between the downstream client   and the Gateway is terminated at the Gateway. This mode requires   certificateRef to be set. - Passthrough: The TLS session is NOT terminated by the Gateway. This   implies that the Gateway can't decipher the TLS stream except for   the ClientHello message of the TLS protocol.   CertificateRef field is ignored in this mode. \n Support: Core"
                           enum:
                           - Terminate
                           - Passthrough
@@ -212,7 +213,7 @@ spec:
                         routeOverride:
                           default:
                             certificate: Deny
-                          description: "RouteOverride dictates if TLS settings can be configured via Routes or not. \n CertificateRef must be defined even if `routeOverride.certificate` is set to 'Allow' as it will be used as the default certificate for the listener."
+                          description: "RouteOverride dictates if TLS settings can be configured via Routes or not. \n CertificateRef must be defined even if `routeOverride.certificate` is set to 'Allow' as it will be used as the default certificate for the listener. \n Support: Core"
                           properties:
                             certificate:
                               default: Deny

--- a/docs-src/spec.md
+++ b/docs-src/spec.md
@@ -1702,11 +1702,13 @@ TLSModeType
 <p>Mode defines the TLS behavior for the TLS session initiated by the client.
 There are two possible modes:
 - Terminate: The TLS session between the downstream client
-and the Gateway is terminated at the Gateway.
+and the Gateway is terminated at the Gateway. This mode requires
+certificateRef to be set.
 - Passthrough: The TLS session is NOT terminated by the Gateway. This
 implies that the Gateway can&rsquo;t decipher the TLS stream except for
 the ClientHello message of the TLS protocol.
 CertificateRef field is ignored in this mode.</p>
+<p>Support: Core</p>
 </td>
 </tr>
 <tr>
@@ -1720,15 +1722,16 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertificateRef is the reference to Kubernetes object that
-contain a TLS certificate and private key.
-This certificate MUST be used for TLS handshakes for the domain
-this GatewayTLSConfig is associated with.
-If an entry in this list omits or specifies the empty
-string for both the group and the resource, the resource defaults to &ldquo;secrets&rdquo;.
-An implementation may support other resources (for example, resource
-&ldquo;mycertificates&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Support: Core (Kubernetes Secrets)
+<p>CertificateRef is the reference to Kubernetes object that contain a
+TLS certificate and private key. This certificate MUST be used for
+TLS handshakes for the domain this GatewayTLSConfig is associated with.</p>
+<p>This field is required when mode is set to &ldquo;Terminate&rdquo; (default) and
+optional otherwise.</p>
+<p>If an entry in this list omits or specifies the empty string for both
+the group and the resource, the resource defaults to &ldquo;secrets&rdquo;. An
+implementation may support other resources (for example, resource
+&ldquo;mycertificates&rdquo; in group &ldquo;networking.acme.io&rdquo;).</p>
+<p>Support: Core (Kubernetes Secrets)
 Support: Implementation-specific (Other resource types)</p>
 </td>
 </tr>
@@ -1747,6 +1750,7 @@ via Routes or not.</p>
 <p>CertificateRef must be defined even if <code>routeOverride.certificate</code> is
 set to &lsquo;Allow&rsquo; as it will be used as the default certificate for the
 listener.</p>
+<p>Support: Core</p>
 </td>
 </tr>
 <tr>

--- a/docs/spec/index.html
+++ b/docs/spec/index.html
@@ -2257,11 +2257,13 @@ TLSModeType
 <p>Mode defines the TLS behavior for the TLS session initiated by the client.
 There are two possible modes:
 - Terminate: The TLS session between the downstream client
-and the Gateway is terminated at the Gateway.
+and the Gateway is terminated at the Gateway. This mode requires
+certificateRef to be set.
 - Passthrough: The TLS session is NOT terminated by the Gateway. This
 implies that the Gateway can&rsquo;t decipher the TLS stream except for
 the ClientHello message of the TLS protocol.
 CertificateRef field is ignored in this mode.</p>
+<p>Support: Core</p>
 </td>
 </tr>
 <tr>
@@ -2275,15 +2277,16 @@ LocalObjectReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>CertificateRef is the reference to Kubernetes object that
-contain a TLS certificate and private key.
-This certificate MUST be used for TLS handshakes for the domain
-this GatewayTLSConfig is associated with.
-If an entry in this list omits or specifies the empty
-string for both the group and the resource, the resource defaults to &ldquo;secrets&rdquo;.
-An implementation may support other resources (for example, resource
-&ldquo;mycertificates&rdquo; in group &ldquo;networking.acme.io&rdquo;).
-Support: Core (Kubernetes Secrets)
+<p>CertificateRef is the reference to Kubernetes object that contain a
+TLS certificate and private key. This certificate MUST be used for
+TLS handshakes for the domain this GatewayTLSConfig is associated with.</p>
+<p>This field is required when mode is set to &ldquo;Terminate&rdquo; (default) and
+optional otherwise.</p>
+<p>If an entry in this list omits or specifies the empty string for both
+the group and the resource, the resource defaults to &ldquo;secrets&rdquo;. An
+implementation may support other resources (for example, resource
+&ldquo;mycertificates&rdquo; in group &ldquo;networking.acme.io&rdquo;).</p>
+<p>Support: Core (Kubernetes Secrets)
 Support: Implementation-specific (Other resource types)</p>
 </td>
 </tr>
@@ -2302,6 +2305,7 @@ via Routes or not.</p>
 <p>CertificateRef must be defined even if <code>routeOverride.certificate</code> is
 set to &lsquo;Allow&rsquo; as it will be used as the default certificate for the
 listener.</p>
+<p>Support: Core</p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Service APIs, please read our
   developer guide (https://kubernetes-sigs.github.io/service-apis/devguide/)
   and our community page (https://kubernetes-sigs.github.io/service-apis/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Properly sets the "Terminate" default for `gateway.spec.tls.mode`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/service-apis/issues/517

**Does this PR introduce a user-facing change?**:
Yes, sets the default TLS mode to "Terminate".
