### PR TITLE
disable verbose logging for verify target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ uninstall:
 # Run static analysis.
 .PHONY: verify
 verify:
-	hack/verify-all.sh -v
+	hack/verify-all.sh
 
 # Build the documentation.
 .PHONY: docs


### PR DESCRIPTION
While verbose output is usually helpful, in the current output in CI, it
is so verbose that it is hard to make out the exact cause of a failure.

<!--  Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time contributing to Service APIs, please read our
   developer guide (https://kubernetes-sigs.github.io/service-apis/devguide/)
   and our community page (https://kubernetes-sigs.github.io/service-apis/community/).
2. If this is your first time contributing to a Kubernetes project, please read
   our contributor guidelines:
   https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution
3. Please label this pull request according to what type of issue you are
   addressing, especially if this is a release targeted pull request. For
   reference on required PR/issue labels, read here:
   https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
4. If you want *faster* PR reviews, read how:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it:
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind cleanup
**What this PR does / why we need it**:

Improve developer experience of debugging CI failures.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #522

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, please enter a release note below:
-->
```release-note
NONE
```
