### PR TITLE
indented api-overview.md to 80 chars

### DIFF
--- a/docs-src/api-overview.md
+++ b/docs-src/api-overview.md
@@ -12,8 +12,8 @@ There are 3 primary roles in Service APIs:
 
 There could be a fourth role of Application Admin in some use cases.
 
-Please refer to the [roles and personas](security-model.md#roles-and-personas) section
-in the Security model for details.
+Please refer to the [roles and personas](security-model.md#roles-and-personas) 
+section in the Security model for details.
 
 ## Resource model
 
@@ -23,47 +23,64 @@ in the Security model for details.
 
 There are three main types of objects in our resource model:
 
-*GatewayClass* defines a set of gateways with a common configuration and behavior.
+*GatewayClass* defines a set of gateways with a common configuration and 
+behavior.
 
-*Gateway* requests a point where traffic can be translated to Services within the cluster.
+*Gateway* requests a point where traffic can be translated to Services within 
+the cluster.
 
 *Routes* describe how traffic coming via the Gateway maps to the Services.
 
 ### GatewayClass
 
-GatewayClass defines a set of Gateways that share a common configuration and behaviour.
-Each GatewayClass will be handled by a single controller, although controllers MAY handle more than one.
+GatewayClass defines a set of Gateways that share a common configuration and
+behaviour. Each GatewayClass will be handled by a single controller, although
+controllers MAY handle more than one.
 
-GatewayClass is a cluster-scoped resource.
-There MUST be at least one GatewayClass defined in order to be able to have functional Gateways.
-A controller that implements the Gateway API does so by providing an associated GatewayClass resource that the user can reference from their Gateway(s).
+GatewayClass is a cluster-scoped resource. There MUST be at least one
+GatewayClass defined in order to be able to have functional Gateways. A
+controller that implements the Gateway API does so by providing an associated
+GatewayClass resource that the user can reference from their Gateway(s).
 
-This is similar to [IngressClass](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingress-class) for Ingress and [StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for PersistentVolumes.
-In Ingress v1beta1, the closest analog to GatewayClass is the `ingress-class` annotation, and in IngressV1, the closest analog is the IngressClass object.
+This is similar to
+[IngressClass](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingress-class)
+for Ingress and
+[StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) for
+PersistentVolumes. In Ingress v1beta1, the closest analog to GatewayClass is the
+`ingress-class` annotation, and in IngressV1, the closest analog is the
+IngressClass object.
 
 ### Gateway
 
-A Gateway describes how traffic can be translated to Services within the cluster.
-That is, it defines a request for a way to translate traffic from somewhere that does not know about Kubernetes to somewhere that does.
-For example, traffic sent to a Kubernetes Service by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
-While many use cases have client traffic originating “outside” the cluster, this is not a requirement.
+A Gateway describes how traffic can be translated to Services within the
+cluster. That is, it defines a request for a way to translate traffic from
+somewhere that does not know about Kubernetes to somewhere that does. For
+example, traffic sent to a Kubernetes Service by a cloud load balancer, an
+in-cluster proxy or external hardware load balancer. While many use cases have
+client traffic originating “outside” the cluster, this is not a requirement.
 
-It defines a request for a specific load balancer config that implements the GatewayClass’ configuration and behaviour contract.
-The resource MAY be created by an operator directly, or MAY be created by a controller handling a GatewayClass.
+It defines a request for a specific load balancer config that implements the
+GatewayClass’ configuration and behaviour contract. The resource MAY be created
+by an operator directly, or MAY be created by a controller handling a
+GatewayClass.
 
-As the Gateway spec captures user intent, it may not contain a complete specification for all attributes in the spec.
-For example, the user may omit fields such as addresses, ports, TLS settings.
-This allows the controller managing the GatewayClass to provide these settings for the user, resulting in a more portable spec.
-This behaviour will be made clear using the GatewayClass Status object.
+As the Gateway spec captures user intent, it may not contain a complete
+specification for all attributes in the spec. For example, the user may omit
+fields such as addresses, ports, TLS settings. This allows the controller
+managing the GatewayClass to provide these settings for the user, resulting in a
+more portable spec. This behaviour will be made clear using the GatewayClass
+Status object.
 
-A Gateway MAY contain one or more *Route references which serve to direct traffic for a subset of traffic to a specific service.
+A Gateway MAY contain one or more *Route references which serve to direct
+traffic for a subset of traffic to a specific service.*
 
 ### {HTTP,TCP,Foo}Route
 
-Route objects define protocol-specific rules for mapping requests from a Gateway to Kubernetes Services.
+Route objects define protocol-specific rules for mapping requests from a Gateway
+to Kubernetes Services.
 
-`HTTPRoute` and `TCPRoute` are currently the only defined Route objects. Additional protocol-specific Route
-objects may be added in the future.
+`HTTPRoute` and `TCPRoute` are currently the only defined Route objects.
+Additional protocol-specific Route objects may be added in the future.
 
 ### BackendPolicy
 
@@ -90,18 +107,20 @@ relationships between the different resources:
 
 ## Request flow
 
-A typical client/gateway API request flow for a gateway implemented using a reverse proxy is:
+A typical client/gateway API request flow for a gateway implemented using a
+reverse proxy is:
 
  1. A client makes a request to http://foo.example.com.
  2. DNS resolves the name to a `Gateway` address.
- 3. The reverse proxy receives the request on a `Listener` and uses the
- [Host header](https://tools.ietf.org/html/rfc7230#section-5.4) to match an `HTTPRoute`.
- 5. Optionally, the reverse proxy can perform request header and/or path matching based
- on `match` rules of the `HTTPRoute`.
- 6. Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based
- on `filter` rules of the `HTTPRoute`.
- 7. Lastly, the reverse proxy forwards the request to one or more objects, i.e. `Service`,
- in the cluster based on `forwardTo` rules of the `HTTPRoute`.
+ 3. The reverse proxy receives the request on a `Listener` and uses the [Host
+ header](https://tools.ietf.org/html/rfc7230#section-5.4) to match an
+ `HTTPRoute`.
+ 5. Optionally, the reverse proxy can perform request header and/or path
+ matching based on `match` rules of the `HTTPRoute`.
+ 6. Optionally, the reverse proxy can modify the request, i.e. add/remove
+ headers, based on `filter` rules of the `HTTPRoute`. 
+ 7. Lastly, the reverse proxy forwards the request to one or more objects, i.e.
+ `Service`, in the cluster based on `forwardTo` rules of the `HTTPRoute`.
 
 ## TLS Configuration
 
@@ -125,8 +144,8 @@ Here is a summary of extension points in the API:
 - **XForwardTo.BackendRef**: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.
-- **HTTPRouteFilter**: This API type in HTTPRoute provides a way to hook into the
-  request/response lifecycle of an HTTP request.
+- **HTTPRouteFilter**: This API type in HTTPRoute provides a way to hook into 
+the request/response lifecycle of an HTTP request.
 - **Custom Routes**: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols
   that are not currently supported in the API.

--- a/docs/api-overview/index.html
+++ b/docs/api-overview/index.html
@@ -761,8 +761,8 @@
 <li>Application Developer</li>
 </ul>
 <p>There could be a fourth role of Application Admin in some use cases.</p>
-<p>Please refer to the <a href="../security-model/#roles-and-personas">roles and personas</a> section
-in the Security model for details.</p>
+<p>Please refer to the <a href="../security-model/#roles-and-personas">roles and personas</a> 
+section in the Security model for details.</p>
 <h2 id="resource-model">Resource model</h2>
 <blockquote>
 <p>Note: Resources will initially live in the <code>networking.x-k8s.io</code> API group as
@@ -770,33 +770,50 @@ Custom Resource Definitions (CRDs). Unqualified resource names will implicitly
 be in this API group.</p>
 </blockquote>
 <p>There are three main types of objects in our resource model:</p>
-<p><em>GatewayClass</em> defines a set of gateways with a common configuration and behavior.</p>
-<p><em>Gateway</em> requests a point where traffic can be translated to Services within the cluster.</p>
+<p><em>GatewayClass</em> defines a set of gateways with a common configuration and 
+behavior.</p>
+<p><em>Gateway</em> requests a point where traffic can be translated to Services within 
+the cluster.</p>
 <p><em>Routes</em> describe how traffic coming via the Gateway maps to the Services.</p>
 <h3 id="gatewayclass">GatewayClass</h3>
-<p>GatewayClass defines a set of Gateways that share a common configuration and behaviour.
-Each GatewayClass will be handled by a single controller, although controllers MAY handle more than one.</p>
-<p>GatewayClass is a cluster-scoped resource.
-There MUST be at least one GatewayClass defined in order to be able to have functional Gateways.
-A controller that implements the Gateway API does so by providing an associated GatewayClass resource that the user can reference from their Gateway(s).</p>
-<p>This is similar to <a href="https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingress-class">IngressClass</a> for Ingress and <a href="https://kubernetes.io/docs/concepts/storage/storage-classes/">StorageClass</a> for PersistentVolumes.
-In Ingress v1beta1, the closest analog to GatewayClass is the <code>ingress-class</code> annotation, and in IngressV1, the closest analog is the IngressClass object.</p>
+<p>GatewayClass defines a set of Gateways that share a common configuration and
+behaviour. Each GatewayClass will be handled by a single controller, although
+controllers MAY handle more than one.</p>
+<p>GatewayClass is a cluster-scoped resource. There MUST be at least one
+GatewayClass defined in order to be able to have functional Gateways. A
+controller that implements the Gateway API does so by providing an associated
+GatewayClass resource that the user can reference from their Gateway(s).</p>
+<p>This is similar to
+<a href="https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190125-ingress-api-group.md#ingress-class">IngressClass</a>
+for Ingress and
+<a href="https://kubernetes.io/docs/concepts/storage/storage-classes/">StorageClass</a> for
+PersistentVolumes. In Ingress v1beta1, the closest analog to GatewayClass is the
+<code>ingress-class</code> annotation, and in IngressV1, the closest analog is the
+IngressClass object.</p>
 <h3 id="gateway">Gateway</h3>
-<p>A Gateway describes how traffic can be translated to Services within the cluster.
-That is, it defines a request for a way to translate traffic from somewhere that does not know about Kubernetes to somewhere that does.
-For example, traffic sent to a Kubernetes Service by a cloud load balancer, an in-cluster proxy or external hardware load balancer.
-While many use cases have client traffic originating “outside” the cluster, this is not a requirement.</p>
-<p>It defines a request for a specific load balancer config that implements the GatewayClass’ configuration and behaviour contract.
-The resource MAY be created by an operator directly, or MAY be created by a controller handling a GatewayClass.</p>
-<p>As the Gateway spec captures user intent, it may not contain a complete specification for all attributes in the spec.
-For example, the user may omit fields such as addresses, ports, TLS settings.
-This allows the controller managing the GatewayClass to provide these settings for the user, resulting in a more portable spec.
-This behaviour will be made clear using the GatewayClass Status object.</p>
-<p>A Gateway MAY contain one or more *Route references which serve to direct traffic for a subset of traffic to a specific service.</p>
+<p>A Gateway describes how traffic can be translated to Services within the
+cluster. That is, it defines a request for a way to translate traffic from
+somewhere that does not know about Kubernetes to somewhere that does. For
+example, traffic sent to a Kubernetes Service by a cloud load balancer, an
+in-cluster proxy or external hardware load balancer. While many use cases have
+client traffic originating “outside” the cluster, this is not a requirement.</p>
+<p>It defines a request for a specific load balancer config that implements the
+GatewayClass’ configuration and behaviour contract. The resource MAY be created
+by an operator directly, or MAY be created by a controller handling a
+GatewayClass.</p>
+<p>As the Gateway spec captures user intent, it may not contain a complete
+specification for all attributes in the spec. For example, the user may omit
+fields such as addresses, ports, TLS settings. This allows the controller
+managing the GatewayClass to provide these settings for the user, resulting in a
+more portable spec. This behaviour will be made clear using the GatewayClass
+Status object.</p>
+<p>A Gateway MAY contain one or more <em>Route references which serve to direct
+traffic for a subset of traffic to a specific service.</em></p>
 <h3 id="httptcpfooroute">{HTTP,TCP,Foo}Route</h3>
-<p>Route objects define protocol-specific rules for mapping requests from a Gateway to Kubernetes Services.</p>
-<p><code>HTTPRoute</code> and <code>TCPRoute</code> are currently the only defined Route objects. Additional protocol-specific Route
-objects may be added in the future.</p>
+<p>Route objects define protocol-specific rules for mapping requests from a Gateway
+to Kubernetes Services.</p>
+<p><code>HTTPRoute</code> and <code>TCPRoute</code> are currently the only defined Route objects.
+Additional protocol-specific Route objects may be added in the future.</p>
 <h3 id="backendpolicy">BackendPolicy</h3>
 <p>BackendPolicy provides a way to configure connections between a Gateway and a
 backend. For the purpose of this API, a backend is any resource that a route can
@@ -816,18 +833,20 @@ relationships between the different resources:</p>
 
 <p><img alt="schema" src="../images/schema-uml.svg" /></p>
 <h2 id="request-flow">Request flow</h2>
-<p>A typical client/gateway API request flow for a gateway implemented using a reverse proxy is:</p>
+<p>A typical client/gateway API request flow for a gateway implemented using a
+reverse proxy is:</p>
 <ol>
 <li>A client makes a request to http://foo.example.com.</li>
 <li>DNS resolves the name to a <code>Gateway</code> address.</li>
-<li>The reverse proxy receives the request on a <code>Listener</code> and uses the
- <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Host header</a> to match an <code>HTTPRoute</code>.</li>
-<li>Optionally, the reverse proxy can perform request header and/or path matching based
- on <code>match</code> rules of the <code>HTTPRoute</code>.</li>
-<li>Optionally, the reverse proxy can modify the request, i.e. add/remove headers, based
- on <code>filter</code> rules of the <code>HTTPRoute</code>.</li>
-<li>Lastly, the reverse proxy forwards the request to one or more objects, i.e. <code>Service</code>,
- in the cluster based on <code>forwardTo</code> rules of the <code>HTTPRoute</code>.</li>
+<li>The reverse proxy receives the request on a <code>Listener</code> and uses the <a href="https://tools.ietf.org/html/rfc7230#section-5.4">Host
+ header</a> to match an
+ <code>HTTPRoute</code>.</li>
+<li>Optionally, the reverse proxy can perform request header and/or path
+ matching based on <code>match</code> rules of the <code>HTTPRoute</code>.</li>
+<li>Optionally, the reverse proxy can modify the request, i.e. add/remove
+ headers, based on <code>filter</code> rules of the <code>HTTPRoute</code>. </li>
+<li>Lastly, the reverse proxy forwards the request to one or more objects, i.e.
+ <code>Service</code>, in the cluster based on <code>forwardTo</code> rules of the <code>HTTPRoute</code>.</li>
 </ol>
 <h2 id="tls-configuration">TLS Configuration</h2>
 <p>TLS is configured on Gateway listeners. Additionally, TLS certificates
@@ -845,8 +864,8 @@ purpose API.</p>
 <li><strong>XForwardTo.BackendRef</strong>: This extension point should be used for forwarding
   traffic to network endpoints other than core Kubernetes Service resource.
   Examples include an S3 bucket, Lambda function, a file-server, etc.</li>
-<li><strong>HTTPRouteFilter</strong>: This API type in HTTPRoute provides a way to hook into the
-  request/response lifecycle of an HTTP request.</li>
+<li><strong>HTTPRouteFilter</strong>: This API type in HTTPRoute provides a way to hook into 
+the request/response lifecycle of an HTTP request.</li>
 <li><strong>Custom Routes</strong>: If none of the above extensions points suffice for a use
   case, Implementers can chose to create custom Route resources for protocols
   that are not currently supported in the API.</li>


### PR DESCRIPTION
Indented the api-overview.md page to 80 chars. This was originally done in https://github.com/kubernetes-sigs/service-apis/pull/514 but was recommended by @jpeach and @robscott to break out into a separate PR. I'll rebase https://github.com/kubernetes-sigs/service-apis/pull/514 on top of this one once it is merged