### PR TITLE
Add link to "Kubernetes API Versioning" by using correct name

### DIFF
--- a/docs-src/releases.md
+++ b/docs-src/releases.md
@@ -44,7 +44,7 @@ fixes. New API versions will be released with new minor or major versions.
 Our changelog and release notes will always include both the semantic version
 and API version(s) included in the release. 
 
-[Kubernetes API Version]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
+[Kubernetes API Versioning]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions
 [Semantic Versioning]: https://semver.org/
 [Go modules versioning]: https://golang.org/ref/mod#versions
 

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -673,7 +673,7 @@ releases will be independent from Kubernetes releases initially.</p>
 <h2 id="versioning">Versioning</h2>
 <p>This project uses 2 different but related forms of versioning:</p>
 <ul>
-<li>[Kubernetes API Versioning] (example: v1alpha1)</li>
+<li><a href="https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api_changes.md#alpha-beta-and-stable-versions">Kubernetes API Versioning</a> (example: v1alpha1)</li>
 <li><a href="https://semver.org/">Semantic Versioning</a> (example: v0.1.0)</li>
 </ul>
 <p>Each new API version will be released with a new semantic version. For example,


### PR DESCRIPTION
**What this PR does / why we need it**:

[Current doc for Releases/Versioning](https://kubernetes-sigs.github.io/service-apis/releases/#versioning) misses the link for `[Kubernetes API Versioning] (example: v1alpha1)`.
This is because the link is for `Kubernetes API Versioning` does not
match to the `Kubernetes API Version`.

This patch fixes it.

**What type of PR is this?**

/kind documentation

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
