### PR TITLE
Cleaning up codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,20 +21,13 @@ TOP := $(dir $(firstword $(MAKEFILE_LIST)))
 # ROOT is the root of the mkdocs tree.
 ROOT := $(abspath $(TOP))
 
-CONTROLLER_GEN=go run sigs.k8s.io/controller-tools/cmd/controller-gen
-
 all: generate vet fmt verify test
 
 # Run generators for protos, Deepcopy funcs, CRDs, and docs.
 .PHONY: generate
 generate:
-	$(CONTROLLER_GEN) \
-		object:headerFile=./hack/boilerplate/boilerplate.generatego.txt,year=$$(date +%Y) \
-		crd:crdVersions=v1 \
-		output:crd:artifacts:config=config/crd/bases \
-		paths=./...
-	$(MAKE) docs
 	hack/update-codegen.sh
+	$(MAKE) docs
 
 # Run go fmt against code
 fmt:

--- a/apis/v1alpha1/gatewayclass_types.go
+++ b/apis/v1alpha1/gatewayclass_types.go
@@ -26,8 +26,6 @@ import (
 // +kubebuilder:resource:scope=Cluster,shortName=gc
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Controller",type=string,JSONPath=`.spec.controller`
-// +k8s:openapi-gen=true
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // GatewayClass describes a class of Gateways available to the user
 // for creating Gateway resources.

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -45,12 +45,12 @@ fi
 
 readonly COMMON_FLAGS="${VERIFY_FLAG:-} --go-header-file ${SCRIPT_ROOT}/hack/boilerplate/boilerplate.generatego.txt"
 
-echo "Generating deepcopy funcs"
-go run k8s.io/code-generator/cmd/deepcopy-gen \
-        --input-dirs "${FQ_APIS}" \
-        -O zz_generated.deepcopy \
-        --bounding-dirs "${APIS_PKG}" \
-        ${COMMON_FLAGS}
+echo "Generating CRDs and deepcopy"
+go run sigs.k8s.io/controller-tools/cmd/controller-gen \
+        object:headerFile=./hack/boilerplate/boilerplate.generatego.txt \
+        crd:crdVersions=v1 \
+        output:crd:artifacts:config=config/crd/bases \
+        paths=./...
 
 echo "Generating clientset at ${OUTPUT_PKG}/${CLIENTSET_PKG_NAME}"
 go run k8s.io/code-generator/cmd/client-gen \


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We were previously running codegen twice - once with controller-gen, and once with deepcopy-gen. This cleans that up a bit and ensures we're not duplicating work. This also removes some unnecessary annotations from GatewayClass. (They were useful for deepcopy-gen but not for controller-gen).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```